### PR TITLE
[A4] Mount app folder as docker volume.

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/deployments/Dockerfile
@@ -1,6 +1,5 @@
 FROM php:apache
 
-COPY app/ /var/www/html
 COPY deployments/apache.conf /etc/apache2/sites-available/000-default.conf
 COPY deployments/php.ini /usr/local/etc/php/
 

--- a/owasp-top10-2017-apps/a4/vinijr-blog/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/deployments/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     build:
       context: ../
       dockerfile: deployments/Dockerfile
+    volumes:
+      - "../app/:/var/www/html"
     ports:
       - 10080:80


### PR DESCRIPTION
Mount folder as volume, instead to add as image content, to avoid re-run container (`make install`)  to add new changes to Apache server.

Changes are live automatically to docker container server.