### PR TITLE
[A4][Mitigation] Avoid substitute entities in XML load.

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,7 +1,7 @@
 <?php
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
-$dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);
+$dom->loadXML($xmlfile, LIBXML_DTDLOAD);
 $contact = simplexml_import_dom($dom);
 $name = $contact->name;
 $email = $contact->email;


### PR DESCRIPTION
Removing `LIBXML_NOENT` to the XML loader, the entities aren't changed anymore, as shown in the image below:

<img src="https://i.imgur.com/BSwd14W.png" />

