### PR TITLE
[A1][Mitigation] Use prepared statement to avoid injection in SQL queries.

### DIFF
--- a/owasp-top10-2017-apps/a1/copy-n-paste/app/util/db.go
+++ b/owasp-top10-2017-apps/a1/copy-n-paste/app/util/db.go
@@ -43,8 +43,7 @@ func AuthenticateUser(user string, pass string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("select * from Users where username = '" + user + "'")
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.Query("select * from Users where username = ?", user)
 	if err != nil {
 		return false, err
 	}
@@ -82,8 +81,7 @@ func NewUser(user string, pass string, passcheck string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("insert into Users (username, password) values ('" + user + "', '" + passHash + "')")
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.Query("insert into Users (username, password) values (?, ?)", user, passHash)
 	if err != nil {
 		return false, err
 	}
@@ -102,8 +100,7 @@ func CheckIfUserExists(username string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("select username from Users where username = '" + username + "'")
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.Query("select username from Users where username = ?", username)
 	if err != nil {
 		return false, err
 	}

--- a/owasp-top10-2017-apps/a1/copy-n-paste/postRequest.txt
+++ b/owasp-top10-2017-apps/a1/copy-n-paste/postRequest.txt
@@ -1,0 +1,8 @@
+POST /login HTTP/1.1
+Host: 127.0.0.1:3000
+User-Agent: curl/7.54.0
+Accept: */*
+Content-Type: application/json
+Content-Length: 31
+
+{"user":"user", "pass":"password"}

--- a/owasp-top10-2017-apps/a1/copy-n-paste/sqlmap_output.txt
+++ b/owasp-top10-2017-apps/a1/copy-n-paste/sqlmap_output.txt
@@ -1,0 +1,65 @@
+        ___
+       __H__
+ ___ ___[)]_____ ___ ___  {1.3#stable}
+|_ -| . [(]     | .'| . |
+|___|_  [']_|_|_|__,|  _|
+      |_|V          |_|   http://sqlmap.org
+
+[!] legal disclaimer: Usage of sqlmap for attacking targets without prior mutual consent is illegal. It is the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program
+
+[*] starting @ 15:20:55 /2019-01-08/
+
+[15:20:55] [INFO] parsing HTTP request from 'postRequest.txt'
+Y
+[15:20:58] [INFO] testing connection to the target URL
+[15:20:58] [INFO] testing if the target URL content is stable
+[15:20:59] [INFO] target URL content is stable
+[15:20:59] [INFO] testing if (custom) POST parameter 'JSON user' is dynamic
+[15:20:59] [WARNING] (custom) POST parameter 'JSON user' does not appear to be dynamic
+[15:20:59] [WARNING] heuristic (basic) test shows that (custom) POST parameter 'JSON user' might not be injectable
+[15:20:59] [INFO] testing for SQL injection on (custom) POST parameter 'JSON user'
+[15:20:59] [INFO] testing 'AND boolean-based blind - WHERE or HAVING clause'
+[15:21:00] [INFO] testing 'Boolean-based blind - Parameter replace (original value)'
+[15:21:00] [INFO] testing 'MySQL >= 5.0 AND error-based - WHERE, HAVING, ORDER BY or GROUP BY clause (FLOOR)'
+[15:21:00] [INFO] testing 'PostgreSQL AND error-based - WHERE or HAVING clause'
+[15:21:00] [INFO] testing 'Microsoft SQL Server/Sybase AND error-based - WHERE or HAVING clause (IN)'
+[15:21:00] [INFO] testing 'Oracle AND error-based - WHERE or HAVING clause (XMLType)'
+[15:21:00] [INFO] testing 'MySQL >= 5.0 error-based - Parameter replace (FLOOR)'
+[15:21:00] [INFO] testing 'MySQL inline queries'
+[15:21:00] [INFO] testing 'PostgreSQL inline queries'
+[15:21:00] [INFO] testing 'Microsoft SQL Server/Sybase inline queries'
+[15:21:00] [INFO] testing 'PostgreSQL > 8.1 stacked queries (comment)'
+[15:21:00] [INFO] testing 'Microsoft SQL Server/Sybase stacked queries (comment)'
+[15:21:00] [INFO] testing 'Oracle stacked queries (DBMS_PIPE.RECEIVE_MESSAGE - comment)'
+[15:21:00] [INFO] testing 'MySQL >= 5.0.12 AND time-based blind'
+[15:21:00] [INFO] testing 'PostgreSQL > 8.1 AND time-based blind'
+[15:21:00] [INFO] testing 'Microsoft SQL Server/Sybase time-based blind (IF)'
+[15:21:00] [INFO] testing 'Oracle AND time-based blind'
+[15:21:00] [INFO] testing 'Generic UNION query (NULL) - 1 to 10 columns'
+[15:21:01] [WARNING] (custom) POST parameter 'JSON user' does not seem to be injectable
+[15:21:01] [INFO] testing if (custom) POST parameter 'JSON pass' is dynamic
+[15:21:01] [WARNING] (custom) POST parameter 'JSON pass' does not appear to be dynamic
+[15:21:01] [WARNING] heuristic (basic) test shows that (custom) POST parameter 'JSON pass' might not be injectable
+[15:21:01] [INFO] testing for SQL injection on (custom) POST parameter 'JSON pass'
+[15:21:01] [INFO] testing 'AND boolean-based blind - WHERE or HAVING clause'
+[15:21:01] [INFO] testing 'Boolean-based blind - Parameter replace (original value)'
+[15:21:01] [INFO] testing 'MySQL >= 5.0 AND error-based - WHERE, HAVING, ORDER BY or GROUP BY clause (FLOOR)'
+[15:21:01] [INFO] testing 'PostgreSQL AND error-based - WHERE or HAVING clause'
+[15:21:01] [INFO] testing 'Microsoft SQL Server/Sybase AND error-based - WHERE or HAVING clause (IN)'
+[15:21:01] [INFO] testing 'Oracle AND error-based - WHERE or HAVING clause (XMLType)'
+[15:21:02] [INFO] testing 'MySQL >= 5.0 error-based - Parameter replace (FLOOR)'
+[15:21:02] [INFO] testing 'MySQL inline queries'
+[15:21:02] [INFO] testing 'PostgreSQL inline queries'
+[15:21:02] [INFO] testing 'Microsoft SQL Server/Sybase inline queries'
+[15:21:02] [INFO] testing 'PostgreSQL > 8.1 stacked queries (comment)'
+[15:21:02] [INFO] testing 'Microsoft SQL Server/Sybase stacked queries (comment)'
+[15:21:02] [INFO] testing 'Oracle stacked queries (DBMS_PIPE.RECEIVE_MESSAGE - comment)'
+[15:21:02] [INFO] testing 'MySQL >= 5.0.12 AND time-based blind'
+[15:21:02] [INFO] testing 'PostgreSQL > 8.1 AND time-based blind'
+[15:21:02] [INFO] testing 'Microsoft SQL Server/Sybase time-based blind (IF)'
+[15:21:02] [INFO] testing 'Oracle AND time-based blind'
+[15:21:02] [INFO] testing 'Generic UNION query (NULL) - 1 to 10 columns'
+[15:21:03] [WARNING] (custom) POST parameter 'JSON pass' does not seem to be injectable
+[15:21:03] [CRITICAL] all tested parameters do not appear to be injectable. Try to increase values for '--level'/'--risk' options if you wish to perform more tests. If you suspect that there is some kind of protection mechanism involved (e.g. WAF) maybe you could try to use option '--tamper' (e.g. '--tamper=space2comment') and/or switch '--random-agent'
+
+[*] ending @ 15:21:03 /2019-01-08/


### PR DESCRIPTION
Running `sqlmap` with command:

`sqlmap -r postRequest.txt`

The output is: `all tested parameters do not appear to be injectable`.

Full output file `sqlmap_output.txt`.