### PR TITLE
[A7] Mount app folder as docker volume.

### DIFF
--- a/owasp-top10-2017-apps/a7/fofocando/app/routes.py
+++ b/owasp-top10-2017-apps/a7/fofocando/app/routes.py
@@ -205,4 +205,4 @@ if __name__ == '__main__':
     database = DataBase(dbEndpoint, dbUser, dbPassword, dbName)
     init_db(database)
 
-    app.run(host='0.0.0.0',port=3001, debug=False)
+    app.run(host='0.0.0.0',port=3001, debug=True)

--- a/owasp-top10-2017-apps/a7/fofocando/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a7/fofocando/deployments/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3
-ADD app/ /app
 WORKDIR /app
 RUN pip install -r requirements.txt
 CMD python routes.py

--- a/owasp-top10-2017-apps/a7/fofocando/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a7/fofocando/deployments/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: deployments/Dockerfile
     ports:
       - "3001:3001"
+    volumes:
+      - "../app/:/app"
     environment:
       SECRET_KEY: secretkey
       MYSQL_ENDPOINT: mysqldb-a7
@@ -20,7 +22,7 @@ services:
       - mysqldb-a7
     external_links:
       - mysqldb-a7:mysqldb-a7
-    restart: unless-stopped
+    restart: always
     
   mysqldb-a7:
     container_name: mysqldb-a7


### PR DESCRIPTION
Mount folder as volume, instead to add as image content, to avoid re-run container (make install) to add new changes to server.

Changes are live automatically to docker container server.