### PR TITLE
[A8] Mount app folder as docker volume.

### DIFF
--- a/owasp-top10-2017-apps/a8/amarelo-designs/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/deployments/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3
 WORKDIR /app
 ADD app/requirements.txt /app/requirements.txt
+RUN apt-get update && apt-get -y install netcat && apt-get clean
 RUN pip install -r requirements.txt
 CMD python app.py

--- a/owasp-top10-2017-apps/a8/amarelo-designs/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/deployments/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3
-ADD app/ /app
 WORKDIR /app
-RUN apt-get update
+ADD app/requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
 CMD python app.py

--- a/owasp-top10-2017-apps/a8/amarelo-designs/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/deployments/docker-compose.yml
@@ -5,10 +5,13 @@ services:
     build:
       context: ../
       dockerfile: deployments/Dockerfile
+    volumes:
+      - "../app/:/app"
     ports:
       - "5000:5000"
     networks: 
       - a8_net
+    restart: always
 
 networks:
   a8_net:


### PR DESCRIPTION
Mount folder as volume, instead to add as image content, to avoid re-run container (make install) to add new changes to server.

Changes are live automatically to docker container server.

Also install `netcat` to docker image for attack narrative works.