### PR TITLE
[A10] Mount app folder as docker volume.

### DIFF
--- a/owasp-top10-2017-apps/a10/games-irados/app/routes.py
+++ b/owasp-top10-2017-apps/a10/games-irados/app/routes.py
@@ -137,4 +137,4 @@ if __name__ == '__main__':
     dbName = os.environ.get('MYSQL_DB')
     database = DataBase(dbEndpoint, dbUser, dbPassword, dbName)
     init_db(database)
-    app.run(host='0.0.0.0',port=3001, debug=False)
+    app.run(host='0.0.0.0',port=3001, debug=True)

--- a/owasp-top10-2017-apps/a10/games-irados/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a10/games-irados/deployments/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3
-ADD app/ /app
 WORKDIR /app
+ADD app/requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
 CMD python routes.py

--- a/owasp-top10-2017-apps/a10/games-irados/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a10/games-irados/deployments/docker-compose.yml
@@ -20,7 +20,9 @@ services:
          - mysqldb-a10
       external_links:
          - mysqldb-a10:mysqldb-10
-      restart: unless-stopped
+      volumes:
+         - "../app/:/app"
+      restart: always
 
    mysqldb-a10:
       container_name: mysqldb-a10


### PR DESCRIPTION
Mount folder as volume, instead to add as image content, to avoid re-run container (make install) to add new changes to server.

Changes are live automatically to docker container server.