### PR TITLE
[A10] Return success message True only if the user_password is not empty

### DIFF
--- a/owasp-top10-2017-apps/a10/games-irados/app/model/db.py
+++ b/owasp-top10-2017-apps/a10/games-irados/app/model/db.py
@@ -90,7 +90,7 @@ class DataBase:
                 message = "MySQL Error: %s" % str(e)
                 return message , 0
 
-        return user_password, 1
+        return user_password, bool(user_password)
 
     def init_table_user(self):
         try:


### PR DESCRIPTION
The application flow, uses the second return parameter to represent `success` or `fail`, but when the application try to retrieve the `user_password` and it is empty, the `success` parameter continues to be `True` even if this value is empty.

This pull request suggest to return `False` if this value doesn't exists.