### PR TITLE
[A2] Mount app folder as docker volume.

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -111,4 +111,4 @@ def userInfo():
     return "You are an user!"
 
 if __name__ == '__main__':
-    app.run(debug=False, host='0.0.0.0', port=10082)
+    app.run(debug=True, host='0.0.0.0', port=10082)

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:2.7
-ADD app/ /app
 WORKDIR /app
-RUN apt-get update
+ADD app/requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
 CMD python app.py

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
@@ -18,7 +18,9 @@ services:
       - "10082:10082"
     networks:
       - a2_net
-    restart: unless-stopped
+    volumes:
+      - "../app/:/app"
+    restart: always
 
   db:
     container_name: db-a2


### PR DESCRIPTION
Mount folder as volume, instead to add as image content, to avoid re-run container (make install) to add new changes to server.

Changes are live automatically to docker container server.