### PR TITLE
[A2][Mitigation] Use JWT as content for cookies.

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -11,6 +11,8 @@ import time
 import uuid
 from functools import wraps
 import uuid
+import jwt
+from jwt import InvalidSignatureError
 
 
 
@@ -22,15 +24,13 @@ def login_admin_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         cookie = request.cookies.get("sessionId", "")
-        cookie = base64.b64decode(cookie).decode("utf-8")
-        cookie_separado = cookie.split('.')
-        if(len(cookie_separado) != 2 ):
-            return "Invalid cookie!"
-        hash_cookie = hashlib.sha256(cookie_separado[0].encode('utf-8')).hexdigest()
-        if (hash_cookie != cookie_separado[1]):
+
+        try:
+            payload = jwt.decode(cookie, os.environ.get('JWT_SECRET'), algorithm='HS256')
+        except InvalidSignatureError as e:
             return redirect("/login")
-        j = json.loads(cookie_separado[0])
-        if j.get("permissao") != 1:
+
+        if payload.get("permissao") != 1:
             return "You don't have permission to access this route. You are not an admin."
         return f(*args, **kwargs)
     return decorated_function
@@ -39,12 +39,10 @@ def login_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         cookie = request.cookies.get("sessionId", "")
-        cookie = base64.b64decode(cookie).decode("utf-8")
-        cookie_separado = cookie.split('.')
-        if(len(cookie_separado) != 2 ):
-            return "Invalid cookie!"
-        hash_cookie = hashlib.sha256(cookie_separado[0].encode('utf-8')).hexdigest()
-        if (hash_cookie != cookie_separado[1]):
+
+        try:
+            payload = jwt.decode(cookie, os.environ.get('JWT_SECRET'), algorithm='HS256')
+        except InvalidSignatureError as e:
             return redirect("/login")
         return f(*args, **kwargs)
     return decorated_function
@@ -89,13 +87,12 @@ def login():
         if not password.validate_password(result[0]):
             return "Login failed!"
 
-        cookie_dic = {"permissao": result[1], "username": form_username}
-        cookie = json.dumps(cookie_dic)
-        hash_cookie = hashlib.sha256(cookie.encode('utf-8')).hexdigest()
-        cookie_done = '.'.join([cookie,hash_cookie])
-        cookie_done = base64.b64encode(str(cookie_done).encode("utf-8"))
+        payload = {"permissao": result[1], "username": form_username}
+        cookie_done = jwt.encode(payload, os.environ.get('JWT_SECRET'), algorithm='HS256')
+
         resp = make_response()
         resp.set_cookie("sessionId", cookie_done)
+
         return resp
 
 

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from flask import Flask, request, make_response, render_template, redirect, Markup
+from flask import Flask, request, make_response, redirect
 from model.password import Password
 from model.db import DataBase
-import base64
 import os
-import json
-import hashlib, binascii
-import time
 import uuid
 from functools import wraps
-import uuid
 import jwt
 from jwt import InvalidSignatureError
 

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
@@ -10,3 +10,4 @@ mysqlclient==1.3.13
 six==1.11.0
 visitor==0.1.3
 Werkzeug==0.14.1
+PyJWT==1.7.1

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
@@ -5,11 +5,8 @@ services:
     build:
       context: ../
       dockerfile: deployments/Dockerfile
-    environment:
-      A2_DATABASE_USER: user
-      A2_DATABASE_PASSWORD: pass
-      A2_DATABASE_HOST: db
-      A2_DATABASE_NAME: A2
+    env_file:
+      - dockers.env
     links:
       - db:db
     depends_on:
@@ -25,11 +22,8 @@ services:
     image: mysql:5.7
     ports:
       - "3307:3307"
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: A2
-      MYSQL_USER: user
-      MYSQL_PASSWORD: pass
+    env_file:
+      - dockers.env
     networks:
       - a2_net
     volumes:


### PR DESCRIPTION
All environment variables are stored in `deploymens/dockers.env` file.

`deployments/dockers.env` example

```sh
MYSQL_ROOT_PASSWORD=<db_root_password>
MYSQL_DATABASE=<db_name>
MYSQL_USER=<db_user>
MYSQL_PASSWORD=<db_password>
A2_DATABASE_USER=<db_user>
A2_DATABASE_PASSWORD=<db_password>
A2_DATABASE_HOST=<db_host>
A2_DATABASE_NAME=<db_name>
JWT_SECRET=<jwt_secret_key>
```
