### PR TITLE
Replace hardcoded dabatase config with enviroment variables

### DIFF
--- a/owasp-top10-2017-apps/a2/insecure-go-project/app/config.yml
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/app/config.yml
@@ -1,5 +1,0 @@
-mongoConf:
-  mongoPassword: svGX8SViufvYYNu6m3Kv
-  mongoUser: u_insecure_go_project
-  mongoDBName: insecure_go_project
-  mongoHost: mongodb

--- a/owasp-top10-2017-apps/a2/insecure-go-project/app/db/mongo/db.go
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/app/db/mongo/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a2/insecure-go-project/app/config"
@@ -44,9 +45,9 @@ func Connect() (*DB, error) {
 		Addrs:    []string{mongoConfig.MongoHost},
 		Timeout:  time.Second * 60,
 		FailFast: true,
-		Database: mongoConfig.MongoDBName,
-		Username: mongoConfig.MongoUser,
-		Password: mongoConfig.MongoPassword,
+		Database: os.Getenv("A2_DATABASE"),
+		Username: os.Getenv("A2_DATABASE_USER"),
+		Password: os.Getenv("A2_DATABASE_PASS"),
 	}
 	session, err := mgo.DialWithInfo(dialInfo)
 	if err != nil {

--- a/owasp-top10-2017-apps/a2/insecure-go-project/app/db/mongo/db.go
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/app/db/mongo/db.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a2/insecure-go-project/app/config"
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -20,14 +19,6 @@ type DB struct {
 	Session *mgo.Session
 }
 
-// mongoConfig is the struct that represents mongo configuration.
-type mongoConfig struct {
-	Address      string
-	DatabaseName string
-	UserName     string
-	Password     string
-}
-
 // Database is the interface's database.
 type Database interface {
 	Insert(obj interface{}, collection string) error
@@ -40,9 +31,8 @@ type Database interface {
 
 // Connect connects to mongo and returns the session.
 func Connect() (*DB, error) {
-	mongoConfig := config.APIconfiguration.MongoConf
 	dialInfo := &mgo.DialInfo{
-		Addrs:    []string{mongoConfig.MongoHost},
+		Addrs:    []string{os.Getenv("A2_DATABASE_HOST")},
 		Timeout:  time.Second * 60,
 		FailFast: true,
 		Database: os.Getenv("A2_DATABASE"),

--- a/owasp-top10-2017-apps/a2/insecure-go-project/app/main.go
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/app/main.go
@@ -6,26 +6,14 @@ import (
 	"strconv"
 
 	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a2/insecure-go-project/app/api"
-	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a2/insecure-go-project/app/config"
 	db "github.com/globocom/secDevLabs/owasp-top10-2017-apps/a2/insecure-go-project/app/db/mongo"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"github.com/spf13/viper"
 )
 
 func main() {
 
 	fmt.Println("[*] Starting Insecure Go Project...")
-
-	// loading viper
-	viper.SetConfigName("config")
-	viper.AddConfigPath(".")
-	if err := viper.ReadInConfig(); err != nil {
-		errorAPI(err)
-	}
-	if err := viper.Unmarshal(&config.APIconfiguration); err != nil {
-		errorAPI(err)
-	}
 
 	// check if MongoDB is acessible and credentials received are working.
 	if _, err := checkMongoDB(); err != nil {

--- a/owasp-top10-2017-apps/a2/insecure-go-project/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/deployments/docker-compose.yml
@@ -25,6 +25,7 @@ services:
             - A2_DATABASE
             - A2_DATABASE_USER
             - A2_DATABASE_PASS
+            - A2_DATABASE_HOST
 
     mongodb:
         container_name: mongodb

--- a/owasp-top10-2017-apps/a2/insecure-go-project/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/deployments/docker-compose.yml
@@ -21,6 +21,10 @@ services:
             - mongodb
         external_links:
             - mongodb:mongodb
+        environment:
+            - A2_DATABASE
+            - A2_DATABASE_USER
+            - A2_DATABASE_PASS
 
     mongodb:
         container_name: mongodb
@@ -34,3 +38,7 @@ services:
             - mongo_vol:/data/db
         networks:
             - insecure_net
+        environment:
+            DATABASE: ${A2_DATABASE}
+            DATABASE_USER: ${A2_DATABASE_USER}
+            DATABASE_PASS: ${A2_DATABASE_PASS}

--- a/owasp-top10-2017-apps/a2/insecure-go-project/deployments/mongo-init.js
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/deployments/mongo-init.js
@@ -1,9 +1,0 @@
-var db = connect("mongodb://localhost/insecure_go_project");
-
-db.createUser(
-    {
-        user: "u_insecure_go_project",
-        pwd: "svGX8SViufvYYNu6m3Kv",
-        roles: [{ role: "userAdminAnyDatabase", db: "admin" }]
-    }
-);

--- a/owasp-top10-2017-apps/a2/insecure-go-project/deployments/mongo-init.sh
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/deployments/mongo-init.sh
@@ -1,0 +1,7 @@
+mongo "$DATABASE" <<EOF
+var user = '$DATABASE_USER';
+var pwd = '$DATABASE_PASS';
+var admin = db.getSiblingDB('admin');
+admin.auth(user, pwd);
+db.createUser({user: user, pwd: pwd, roles: ["readWrite"]});
+EOF

--- a/owasp-top10-2017-apps/a2/insecure-go-project/deployments/mongo.Dockerfile
+++ b/owasp-top10-2017-apps/a2/insecure-go-project/deployments/mongo.Dockerfile
@@ -1,3 +1,3 @@
 FROM mongo:4.0.3
 
-ADD deployments/mongo-init.js /docker-entrypoint-initdb.d/
+ADD deployments/mongo-init.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
After mitigating the problem, I was having some trouble to make 'mongo-init.js' work, couldn't get the environment variables inside the js file. My teammates gave me a tip to try and use a shell script and it finally worked.
Environment variables needed to run the solution:
A2_DATABASE
A2_DATABASE_USER
A2_DATABASE_PASS
