### PR TITLE
[DOCS] Fix broken link in A4 README

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/README.md
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/README.md
@@ -78,7 +78,7 @@ And run:
 curl -d @payload.xml localhost:10080/contact.php ; echo
 ```
 
-By checking the source code of the [file](../app/contact.php), it is possible to see how this XML is loaded on the server side:
+By checking the source code of the [file](../vinijr-blog/app/contact.php), it is possible to see how this XML is loaded on the server side:
 
 <img src="images/attack-3.png" align="center"/>
 


### PR DESCRIPTION
Link to `contact.php` file was broken.