### PR TITLE
Include a warning before the instruction to install ExploitDB

### DIFF
--- a/owasp-top10-2017-apps/a6/misconfig-wordpress/README.md
+++ b/owasp-top10-2017-apps/a6/misconfig-wordpress/README.md
@@ -134,6 +134,8 @@ As seen from the image above, the tool found out that the CMS version is outdate
 To install this tool, simply type the following in your OSX terminal:
 
 ```sh
+⚠️ 'The next command will install several exploit codes in your system and many of them may trigger antiviruses alerts'
+
 brew install exploitdb
 ```
 

--- a/owasp-top10-2017-apps/a6/stegonography/README.md
+++ b/owasp-top10-2017-apps/a6/stegonography/README.md
@@ -102,6 +102,8 @@ Having a look at the token's name, we get a strong indication that the app might
 To install this tool, simply type the following in your OSX terminal:
 
 ```sh
+⚠️ 'The next command will install several exploit codes in your system and many of them may trigger antiviruses alerts'
+
 brew install exploitdb
 ```
 

--- a/owasp-top10-2017-apps/a9/cimentech/README.md
+++ b/owasp-top10-2017-apps/a9/cimentech/README.md
@@ -69,6 +69,8 @@ Having the CMS version, it's possible to check on [exploit-db][3] if there are a
 By using [searchsploit](https://www.exploit-db.com/searchsploit), an attacker could also find this same result via a terminal. To install it, simply type the following in your OSX terminal (keep in mind it might trigger your anti-virus software) :
 
 ```sh
+⚠️ 'The next command will install several exploit codes in your system and many of them may trigger antiviruses alerts'
+
 brew install exploitdb
 ```
 


### PR DESCRIPTION
## Closes #118 

This PR adds a warning to the README of three web apps about the installation of ExploitDB.

```sh
⚠️ 'The next command will install several exploit codes in your system and many of them may trigger antiviruses alerts'

brew install exploitdb
```