### PR TITLE
[FIX] Remove export from .env file

### DIFF
--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/scripts/generate-passwords.sh
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/scripts/generate-passwords.sh
@@ -12,8 +12,8 @@ echo "MONGO_DATABASE_USERNAME=$MONGO_DATABASE_USERNAME_TMP" > deployments/docker
 echo "MONGO_DATABASE_PASSWORD=$MONGO_DATABASE_PASSWORD_TMP" >> deployments/dockers.env
 
 # Writing passwords into .env to be used by run_create_cert.sh and to send to STDOUT
-echo "export MONGO_DATABASE_USERNAME=\"$MONGO_DATABASE_USERNAME_TMP\"" > .env
-echo "export MONGO_DATABASE_PASSWORD=\"$MONGO_DATABASE_PASSWORD_TMP\"" >> .env
+echo "MONGO_DATABASE_USERNAME=\"$MONGO_DATABASE_USERNAME_TMP\"" > .env
+echo "MONGO_DATABASE_PASSWORD=\"$MONGO_DATABASE_PASSWORD_TMP\"" >> .env
 
 # Preparing script to create mongoDB default user
 cat << EOF > deployments/mongo-init.js


### PR DESCRIPTION
This PR fixes a problem when users start ecommerce-api.

```
mac301188:ecommerce-api manoel.junior$ make install
ERROR: In file ./.env: environment variable name 'export MONGO_DATABASE_USERNAME' may not contains whitespace.
make: *** [compose] Error 1
```

This problem occurs because generated `.env` file needs have only environment variables names and values, and not need `export` command.