### PR TITLE
Upgrade in CSS standard

### DIFF
--- a/owasp-top10-2017-apps/a9/cimentech/app/html/modules/dashboard/dashboard.css
+++ b/owasp-top10-2017-apps/a9/cimentech/app/html/modules/dashboard/dashboard.css
@@ -105,12 +105,12 @@
 }
 
 #dashboard .ui-sortable .block h2 {
-  background: transparent url(../../misc/draggable.png) no-repeat 0px -39px;
+  background: transparent url(../../misc/draggable.png) no-repeat 0 -39px;
   padding: 0 17px;
 }
 
 #dashboard.customize-inactive #disabled-blocks .block:hover h2 {
-  background: #0074BD url(../../misc/draggable.png) no-repeat 0px -39px;
+  background: #0074BD url(../../misc/draggable.png) no-repeat 0 -39px;
   color: #fff;
 }
 

--- a/owasp-top10-2017-apps/a9/cimentech/app/html/modules/dashboard/dashboard.css
+++ b/owasp-top10-2017-apps/a9/cimentech/app/html/modules/dashboard/dashboard.css
@@ -115,8 +115,7 @@
 }
 
 #dashboard.customize-inactive .dashboard-region .ui-sortable .block:hover h2 {
-  background: #0074BD url(../../misc/draggable.png) no-repeat;
-  background-position: 3px -36px;
+  background: #0074BD url(../../misc/draggable.png) no-repeat 3px -36px;
   color: #fff;
 }
 


### PR DESCRIPTION
Unit of measure 'px' is redundant with zero values and properties may be safely replaced with 'background' shorthand