### PR TITLE
[A4] Inclusão da linha para desabilitar o carregamento de entidades (!ENTITY)

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,4 +1,5 @@
 <?php
+libxml_disable_entity_loader (true);
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
 $dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);


### PR DESCRIPTION
O uso de entidades (!ENTITY) em payloads de arquivos de marcação (XML) permite que comandos possam ser executados no lado do servidor, devido a natureza dessa funcionalidade de permitir o atalho para uso de caracteres especiais. O trecho inserido abaixo impede o carregamento desta funcionalidade:

libxml_disable_entity_loader (true);