### PR TITLE
[A4] [Mitigation] Fix XXE

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,7 +1,7 @@
 <?php
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
-$dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);
+$dom->loadXML($xmlfile);
 $contact = simplexml_import_dom($dom);
 $name = $contact->name;
 $email = $contact->email;


### PR DESCRIPTION
Processadores XML antigos permitem a especificação de uma entidade externaI.
Essa falha permite a extração de dados, efetuar requisições no servidor, escanear sistemas internos, realizar DoS attacks, entre outros.
Recomendado aplicar correções ou atualizações e os processadores de XML, bibliotecas e suas dependências, 
Neste caso removido do Código as bibliotecas LIBXML_NOENT e LIBXML_DTDLOAD).
Feito com @felipeStoll