### PR TITLE
[FIX]A4 XML eXternal Entity injection (XXE)

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,7 +1,7 @@
 <?php
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
-$dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);
+$dom->loadXML($xmlfile);
 $contact = simplexml_import_dom($dom);
 $name = $contact->name;
 $email = $contact->email;


### PR DESCRIPTION
What's the problem?
XXE Injection is a type of attack against an application that parses XML input. 

How to resolve?
Removing LIBXML_NOENT and LIBXML_DTDLOAD parameter.
OR
in configuration file input:
libxml_disable_entity_loader(true)

Me and @andrenunesbr