### PR TITLE
Update contact.php

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,5 +1,6 @@
 <?php
 $xmlfile = file_get_contents('php://input');
+libxml_disable_entity_loader(true);
 $dom = new DOMDocument();
 $dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);
 $contact = simplexml_import_dom($dom);


### PR DESCRIPTION
De acordo com a documentação do PHP, o seguinte deve ser definido ao usar o analisador XML XML padrão para evitar o XXE:

libxml_disable_entity_loader(true);

Uma descrição de como abusar disso no PHP é apresentada em um bom artigo do SensePost descrevendo uma vulnerabilidade legal do XXE baseada em PHP que foi corrigida no Facebook.