### PR TITLE
[A1] Fix Server Side Template Injection (SSTI)

### DIFF
--- a/owasp-top10-2017-apps/a1/sstype/src/public/index.html
+++ b/owasp-top10-2017-apps/a1/sstype/src/public/index.html
@@ -28,7 +28,7 @@ background: linear-gradient(90deg, rgba(4,0,57,1) 0%, rgba(4,5,41,1) 46%, rgba(2
     <br>
     <br>
     <img style="align-self: center" src="images/ssti-logo.png" class="center" width="450px" height="200px"/>
-	<h3>Hello: NAMEHERE</h3>
+	<h3>Hello: {{ name }} </h3>
     <h2>Try with /?name=YourName</h2>
 </body>
 </html>

--- a/owasp-top10-2017-apps/a1/sstype/src/server.py
+++ b/owasp-top10-2017-apps/a1/sstype/src/server.py
@@ -12,9 +12,8 @@ for t in TEMPLATE:
 class MainHandler(tornado.web.RequestHandler):
 
     def get(self):
-        name = self.get_argument('name', '')
-        template_data = tmpl.replace("NAMEHERE",name)
-        t = tornado.template.Template(template_data)
+        name =  self.get_argument('name', '')
+        t = tornado.template.Template(tmpl)
         self.write(t.generate(name=name))
 
 application = tornado.web.Application([


### PR DESCRIPTION
'name' input is vulnerable to SSTI when its content is copied directly to the template, replacing 'NAMEHERE' string.
Now, the template is getting the name value from the 'name' variable, which automatically escapes python commands.
