### PR TITLE
Fix XXE vulnerability

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,4 +1,6 @@
 <?php
+
+libxml_disable_entity_loader(true);
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
 $dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);


### PR DESCRIPTION
This PR fixes the XXE vulnerability by adding a call to libxml_disable_entity_loader(true). It disables the ability to load external entities.