### PR TITLE
Parameterizing Querys to Database

### DIFF
--- a/owasp-top10-2017-apps/a1/copy-n-paste/app/util/db.go
+++ b/owasp-top10-2017-apps/a1/copy-n-paste/app/util/db.go
@@ -46,8 +46,7 @@ func AuthenticateUser(user string, pass string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("select * from Users where username = '" + user + "'")
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.Query("select * from Users where username = ?", user)
 	if err != nil {
 		return false, err
 	}
@@ -88,8 +87,7 @@ func NewUser(user string, pass string, passcheck string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("insert into Users (username, password) values ('" + user + "', '" + passHash + "')")
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.Query("insert into Users (username, password) values (?,?)", user, passHash)
 	if err != nil {
 		return false, err
 	}
@@ -108,8 +106,7 @@ func CheckIfUserExists(username string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("select username from Users where username = '" + username + "'")
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.Query("select username from Users where username = ?", username)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This Pull Request prevents SQL Injections by parameterizing all queries to the Database. The `database/sql` package is used to join the query string and parameters, escaping any potential injection before executing it.