### PR TITLE
Using mongo-sanitize to clean inputs

### DIFF
--- a/owasp-top10-2017-apps/a1/mongection/package.json
+++ b/owasp-top10-2017-apps/a1/mongection/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "mongoose": "^5.7.5"
+    "mongoose": "^5.7.5",
+    "mongo-sanitize": "^1.0.1"
   }
 }

--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -1,11 +1,12 @@
 const User = require('./models/user');
+var sanitize = require('mongo-sanitize');
 
 const register = async (user) => {
 
     try { 
         const { name, email, password } = user;
 
-        const existUser = await User.findOne({email: email});
+        const existUser = await User.findOne({ email: sanitize(email) });
 
         if(existUser) { return null }
 
@@ -29,7 +30,7 @@ const login = async (credentials) => {
     try {
         const { email, password } = credentials;
 
-        const existsUser = await User.find({$and: [ { email: email}, { password: password} ]});
+        const existsUser = await User.find({$and: [ { email: sanitize(email)}, { password: sanitize(password)} ]});
 
         if(!existsUser) { return null;}
 


### PR DESCRIPTION
This Pull Request adds the Mongo-Sanitize package to the dependencies list and uses it to clean the username and password inputs before sending the query to the Mongo Driver.

According to Mongo-Sanitize readme:
"The sanitize function will strip out any keys that start with '$' in the input,
so you can pass it to MongoDB without worrying about malicious users overwriting
query selectors."