### PR TITLE
[A2][Saidajaula Monster Fit] Fix broken authentication

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -99,7 +99,7 @@ def login():
 
         refreshToken = jwt.encode(
             {
-                "exp": datetime.utcnow() + timedelta(minutes=5),
+                "exp": datetime.utcnow() + timedelta(days=7),
                 "username": form_username
             },
             os.environ.get('A2_JWT_SECRET'),
@@ -131,7 +131,7 @@ def accessToken():
 
     accessToken = jwt.encode(
         {
-            "exp": datetime.utcnow() + timedelta(minutes=1),
+            "exp": datetime.utcnow() + timedelta(minutes=15),
             "permissao": result[1],
             "username": username
         },

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from flask import Flask, request, make_response, render_template, redirect, Markup
+from datetime import datetime, timedelta
 from model.password import Password
 from model.db import DataBase
 import base64
@@ -97,7 +98,11 @@ def login():
             return "Login failed! \n"
 
         cookie_done = jwt.encode(
-            {"permissao": result[1], "username": form_username},
+            {
+                "exp": datetime.utcnow() + timedelta(days=7),
+                "permissao": result[1],
+                "username": form_username
+            },
             os.environ.get('A2_JWT_SECRET'),
             algorithm="HS256"
         )

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -96,14 +96,14 @@ def login():
         if not password.validate_password(result[0]):
             return "Login failed! \n"
 
-        encoded = jwt.encode(
+        cookie_done = jwt.encode(
             {"permissao": result[1], "username": form_username},
             os.environ.get('A2_JWT_SECRET'),
             algorithm="HS256"
         )
 
         resp = make_response("Logged in!")
-        resp.set_cookie("sessionId", encoded)
+        resp.set_cookie("sessionId", cookie_done)
         return resp
 
 

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/app.py
@@ -124,10 +124,10 @@ def accessToken():
 
     result, success = database.get_user(username)
     if not success or result is None:
-        return "Login failed! \n"
+        return "Authentication failed! \n"
 
     if result is None:
-        return "Login failed! \n"
+        return "Authentication failed! \n"
 
     accessToken = jwt.encode(
         {

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
@@ -7,6 +7,7 @@ itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.0
 mysqlclient==1.3.13
+PyJWT==1.7.1
 six==1.11.0
 visitor==0.1.3
 Werkzeug==0.14.1

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       A2_DATABASE_PASSWORD: pass
       A2_DATABASE_HOST: db
       A2_DATABASE_NAME: A2
+      A2_JWT_SECRET: secret
     links:
       - db:db
     depends_on:


### PR DESCRIPTION
Fix broken authentication by using [JWT](https://jwt.io/) as session cookies. Implemented using [PyJWT](https://pyjwt.readthedocs.io/en/latest/index.html). The secret for the HMAC must be provided via the `A2_JWT_SECRET` environment variable. Some remarks:
* Any validation error (a `jwt.InvalidTokenError` exception) will trigger a redirect to `/login`
* The JWT does not have an expiration date set
