### PR TITLE
[A5][Vulnerable Ecommerce API] Read user id from token instead of route

### DIFF
--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/handlers.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a5/ecommerce-api/app/db"
 	"github.com/labstack/echo"
 )
@@ -15,8 +16,25 @@ func HealthCheck(c echo.Context) error {
 
 // GetTicket returns the userID ticket.
 func GetTicket(c echo.Context) error {
-	id := c.Param("id")
-	userDataQuery := map[string]interface{}{"userID": id}
+	cookie, err := c.Cookie("sessionIDa5")
+	if err != nil {
+		return c.String(http.StatusUnauthorized, "Error reading session cookie")
+	}
+
+	claims := jwt.MapClaims{}
+	_, err = jwt.ParseWithClaims(cookie.Value, claims, func(*jwt.Token) (interface{}, error) {
+		return []byte(JWTSecret), nil
+	})
+	if err != nil {
+		return c.String(http.StatusUnauthorized, "Error parsing token")
+	}
+
+	userID, ok := claims["id"]
+	if !ok {
+		return c.String(http.StatusUnauthorized, "Error parsing token: missing claim for id")
+	}
+
+	userDataQuery := map[string]interface{}{"userID": userID}
 	userDataResult, err := db.GetUserData(userDataQuery)
 	if err != nil {
 		// could not find this user in MongoDB (or MongoDB err connection)

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/handlers.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a5/ecommerce-api/app/db"
@@ -23,7 +24,7 @@ func GetTicket(c echo.Context) error {
 
 	claims := jwt.MapClaims{}
 	_, err = jwt.ParseWithClaims(cookie.Value, claims, func(*jwt.Token) (interface{}, error) {
-		return []byte(JWTSecret), nil
+		return []byte(os.Getenv("JWT_SECRET")), nil
 	})
 	if err != nil {
 		return c.String(http.StatusUnauthorized, "Error parsing token")

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
@@ -13,6 +13,9 @@ import (
 	"github.com/labstack/echo"
 )
 
+// JWTSecret is the secret used to sign JWTs
+const JWTSecret = "secret"
+
 // WriteCookie writes a cookie into echo Context
 func WriteCookie(c echo.Context, jwt string) error {
 	cookie := new(http.Cookie)
@@ -67,10 +70,11 @@ func Login(c echo.Context) error {
 	// Set claims
 	claims := token.Claims.(jwt.MapClaims)
 	claims["name"] = userDataResult.Username
+	claims["id"] = userDataResult.UserID
 	claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	// Generate encoded token and send it as response.
-	t, err := token.SignedString([]byte("secret"))
+	t, err := token.SignedString([]byte(JWTSecret))
 	if err != nil {
 		return err
 	}

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -12,9 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo"
 )
-
-// JWTSecret is the secret used to sign JWTs
-const JWTSecret = "secret"
 
 // WriteCookie writes a cookie into echo Context
 func WriteCookie(c echo.Context, jwt string) error {
@@ -74,7 +72,7 @@ func Login(c echo.Context) error {
 	claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	// Generate encoded token and send it as response.
-	t, err := token.SignedString([]byte(JWTSecret))
+	t, err := token.SignedString([]byte(os.Getenv("JWT_SECRET")))
 	if err != nil {
 		return err
 	}

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/server.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/server.go
@@ -56,7 +56,7 @@ func main() {
 
 	echoInstance.GET("/", handlers.FormPage)
 	echoInstance.GET("/healthcheck", handlers.HealthCheck)
-	echoInstance.GET("/ticket/:id", handlers.GetTicket)
+	echoInstance.GET("/ticket", handlers.GetTicket)
 	echoInstance.POST("/register", handlers.RegisterUser)
 	echoInstance.POST("/login", handlers.Login)
 

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/views/form.html
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/views/form.html
@@ -122,7 +122,7 @@ document.getElementById('login').addEventListener('submit', (e) => {
                         
                     }
                 };
-                XHRticket.open('GET', '//localhost:10005/ticket/'+jsonResponse["user_id"]+'?format=json');
+                XHRticket.open('GET', '//localhost:10005/ticket?format=json');
                 XHRticket.setRequestHeader('Content-Type','application/json' );
                 XHRticket.send();
             } else {

--- a/owasp-top10-2017-apps/a5/ecommerce-api/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/deployments/docker-compose.yml
@@ -12,6 +12,7 @@ services:
             MONGO_TIMEOUT: 60
             MONGO_PORT: 27017
             MONGO_TIMEOUT: 60
+            JWT_SECRET: secret
         env_file:
             - dockers.env
         build:


### PR DESCRIPTION
Fix broken access control by reading user id from token instead of route
- Add `user_id` to JWT claims
- Remove `user_id` from the `/ticket` route, since it is obtained from the JWT, which is now mandatory