### PR TITLE
[A6][Stegonography] Set node env, rename session cookie, change admin password

### DIFF
--- a/owasp-top10-2017-apps/a6/stegonography/app/index.js
+++ b/owasp-top10-2017-apps/a6/stegonography/app/index.js
@@ -89,7 +89,7 @@ router.post("/login", function(req,res)  {
             var token = jwt.sign({ username }, process.env.SECRET, {
                 expiresIn: 300 // Token expires in 5 minutes
             });
-            res.cookie('nodejsSessionToken', token).redirect(301, "/admin");
+            res.cookie('sessionToken', token).redirect(301, "/admin");
         } else {
             res.status(500).send('Invalid username or password!').redirect(301, "/logout");
         }
@@ -98,7 +98,7 @@ router.post("/login", function(req,res)  {
 
 // Logout route to deauthorize user session tokens
 router.get("/logout", function(req, res) {
-    res.status(200).clearCookie('nodejsSessionToken').redirect(301, "/");
+    res.status(200).clearCookie('sessionToken').redirect(301, "/");
 });
 
 // Admin maintenance page
@@ -133,7 +133,7 @@ app.listen(10006, () => {
 
 // Verifies the JWT token
 function verifyJWT(req, res, next){
-    var token = req.cookies.nodejsSessionToken;
+    var token = req.cookies.sessionToken;
     if (!token) return res.status(401).send({auth: false, message: 'No token provided'});
 
     jwt.verify(token, process.env.SECRET, function(err, decoded) {

--- a/owasp-top10-2017-apps/a6/stegonography/app/index.js
+++ b/owasp-top10-2017-apps/a6/stegonography/app/index.js
@@ -48,7 +48,7 @@ MongoClient.connect(url, function(err, db) {
 MongoClient.connect(url, function(err, db) {
     if (err) throw err;
     var dbo = db.db("stego");
-    var myobj = { username: "admin", password: "admin" };
+    var myobj = { username: "admin", password: process.env.ADMIN_PASSWORD };
     dbo.collection("users").insertOne(myobj, function(err, res) {
         if (err) throw err;
         console.log("Admin user added to the database");

--- a/owasp-top10-2017-apps/a6/stegonography/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a6/stegonography/deployments/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: deployments/api.Dockerfile
     env_file:
       - .dockers.env
+    environment:
+      - NODE_ENV=production
     ports:
       - 10006:10006
     networks:

--- a/owasp-top10-2017-apps/a6/stegonography/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a6/stegonography/deployments/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - .dockers.env
     environment:
       - NODE_ENV=production
+      - ADMIN_PASSWORD=correcthorsebatterystaple
     ports:
       - 10006:10006
     networks:


### PR DESCRIPTION
Fix security misconfiguration:
- Set nodejs environment to `production`, disabling stack traces
- Rename session cookie 
- Change admin password and read it from environment