### PR TITLE
Using PyJWT to create secure session cookies.

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/Makefile
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/Makefile
@@ -12,7 +12,13 @@ PORT := 10002
 SLEEPUNTILAPPSTARTS := 45
 
 ## Installs a development environment
-install: compose msg
+install: config compose msg
+
+## Creates config file with Secret Key (if not exists)
+config:
+	test -f app/config.py  || touch app/config.py
+	cat app/config.py | grep -q SECRET_KEY || { echo "SECRET_KEY='" | tr -d "\n"; openssl rand -base64 12 | tr -d "\n"; echo "'"; } >> app/config.py
+
 
 ## Composes project using docker-compose
 compose:

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
@@ -10,3 +10,4 @@ mysqlclient==1.3.13
 six==1.11.0
 visitor==0.1.3
 Werkzeug==0.14.1
+PyJWT==1.7.1


### PR DESCRIPTION
This Pull Request uses PyJWT package to create secure session cookies. The Makefile creates a config file with a Secret Key that is used to cryptographically sign all cookies created by the App. 

By using a signed cookie with JWT, an attacker will not be able to generate a fake cookie and obtain admin privileges without having the app secret key, thus fixing the broken authentication vulnerability.