### PR TITLE
[A8][Amarelo Designs] Introduce JWT to store sessions

### DIFF
--- a/owasp-top10-2017-apps/a8/amarelo-designs/app/app.py
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/app/app.py
@@ -4,6 +4,7 @@ from flask import Flask, request, make_response, render_template, redirect, flas
 import uuid
 import pickle
 import base64
+import os
 app = Flask(__name__)
 
 
@@ -17,7 +18,7 @@ def login():
         username = request.values.get('username')
         password = request.values.get('password')
     
-        if username == "admin" and password == "admin":
+        if username == "admin" and password == os.environ['ADMIN_PASSWORD']:
             token = str(uuid.uuid4().hex)
             cookie = { "username":username, "admin":True, "sessionId":token }
             pickle_resultado = pickle.dumps(cookie)

--- a/owasp-top10-2017-apps/a8/amarelo-designs/app/requirements.txt
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/app/requirements.txt
@@ -1,2 +1,3 @@
 flask
 Flask
+PyJWT==1.7.1

--- a/owasp-top10-2017-apps/a8/amarelo-designs/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/deployments/docker-compose.yml
@@ -1,16 +1,18 @@
 version: "2"
 services:
   app:
-    container_name: app-a8 
+    container_name: app-a8
     build:
       context: ../
       dockerfile: deployments/Dockerfile
+    environment:
+      - ADMIN_PASSWORD=correcthorsebatterystaple
     volumes:
       - "../app/:/app"
     ports:
       - "10008:5000"
       - "9051:9051"
-    networks: 
+    networks:
       - a8_net
     restart: always
 

--- a/owasp-top10-2017-apps/a8/amarelo-designs/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a8/amarelo-designs/deployments/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: deployments/Dockerfile
     environment:
       - ADMIN_PASSWORD=correcthorsebatterystaple
+      - JWT_SECRET=supersecretsecret
     volumes:
       - "../app/:/app"
     ports:


### PR DESCRIPTION
Fix insecure deserialization by removing Pickle and using JWTs to store sessions. It would be also interesting to implement a refresh / access tokens as I did in #379.
Also removes hardcoded credentials from source.