### PR TITLE
Use of JWT to check user ID and generation of strong Secret Key

### DIFF
--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/handlers.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/globocom/secDevLabs/owasp-top10-2017-apps/a5/ecommerce-api/app/db"
@@ -27,7 +28,7 @@ func GetTicket(c echo.Context) error {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
-		return []byte("secret"), nil
+		return []byte(os.Getenv("SECRET_KEY")), nil
 	})
 
 	claims, ok := token.Claims.(jwt.MapClaims)

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -71,7 +72,7 @@ func Login(c echo.Context) error {
 	claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	// Generate encoded token and send it as response.
-	t, err := token.SignedString([]byte("secret"))
+	t, err := token.SignedString([]byte(os.Getenv("SECRET_KEY")))
 	if err != nil {
 		return err
 	}

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/handlers/session.go
@@ -67,6 +67,7 @@ func Login(c echo.Context) error {
 	// Set claims
 	claims := token.Claims.(jwt.MapClaims)
 	claims["name"] = userDataResult.Username
+	claims["userID"] = userDataResult.UserID
 	claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	// Generate encoded token and send it as response.

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/scripts/generate-passwords.sh
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/scripts/generate-passwords.sh
@@ -6,10 +6,12 @@
 # Generating "random" passwords
 MONGO_DATABASE_USERNAME_TMP="User$RANDOM$RANDOM"
 MONGO_DATABASE_PASSWORD_TMP="Pass$RANDOM$RANDOM"
+SECRET_KEY=$(openssl rand -base64 12)
 
 # Writing passwords into dockers.env file to be used by docker compose
 echo "MONGO_DATABASE_USERNAME=$MONGO_DATABASE_USERNAME_TMP" > deployments/dockers.env
 echo "MONGO_DATABASE_PASSWORD=$MONGO_DATABASE_PASSWORD_TMP" >> deployments/dockers.env
+echo "SECRET_KEY=$SECRET_KEY" >> deployments/dockers.env
 
 # Writing passwords into .env to be used by run_create_cert.sh and to send to STDOUT
 echo "MONGO_DATABASE_USERNAME=\"$MONGO_DATABASE_USERNAME_TMP\"" > .env

--- a/owasp-top10-2017-apps/a5/ecommerce-api/app/server.go
+++ b/owasp-top10-2017-apps/a5/ecommerce-api/app/server.go
@@ -87,6 +87,7 @@ func checkEnvVars() error {
 		"MONGO_DATABASE_NAME",
 		"MONGO_DATABASE_USERNAME",
 		"MONGO_DATABASE_PASSWORD",
+		"SECRET_KEY",
 	}
 
 	var envIsSet bool


### PR DESCRIPTION
This Pull Request uses JWT to store the userID of the current user on a session cookie. When a user logs in, a JWT is created containing its userID as part of the payload. When a user tries to get a ticket, the JWT content is verified to make sure he is the owner of that ticket.

Additionally, this PR changes the secret_key used to sign the JWT. It uses openssl to randomly generate a strong key and stores it as an environment variable.