### PR TITLE
Fix Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/mitigation-solution.md
+++ b/.github/PULL_REQUEST_TEMPLATE/mitigation-solution.md
@@ -1,8 +1,0 @@
-**This solution refers to which of the apps?**
-A# - App's name here
-
-**What did you do to mitigate the vulnerability?**
-A clear and concise description of what you did. Keep in mind that, if your solution is accepted, this PR will be listed as possible solutions, so do your best to explain it clearly! 😁
-
-**Did you test your changes? What commands did you run?**
-A good start would be trying to reproduce the attack narrative! 😁

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## This solution refers to which of the apps?
+
+A/M# - App's name here
+
+## What did you do to mitigate the vulnerability?
+
+A clear and concise description of what you did. Keep in mind that, if your solution is accepted, this PR will be listed as possible solutions, so do your best to explain it clearly! 😁
+
+Images are not necessary but are greatly appreciated! 📸
+
+## Did you test your changes? What commands did you run?
+
+A good place to start would be trying to reproduce the attack narrative and not being able to successfully exploit the app anymore.


### PR DESCRIPTION
## Closes #404

We've had for quite a while a Pull Request template that wasn't really working where it was. The goal of this PR is to set the path and the file name right so every new PR will use it.

### Changes:

* `.github/PULL_REQUEST_TEMPLATE/mitigation-solution.md`: Removed old PR template.
* `.github/pull_request_template.md` : Adds new PR template.