### PR TITLE
[A1][SSType] Fix the SSTI vulnerability using double curly braces

### DIFF
--- a/owasp-top10-2017-apps/a1/sstype/src/public/index.html
+++ b/owasp-top10-2017-apps/a1/sstype/src/public/index.html
@@ -28,7 +28,7 @@ background: linear-gradient(90deg, rgba(4,0,57,1) 0%, rgba(4,5,41,1) 46%, rgba(2
     <br>
     <br>
     <img style="align-self: center" src="images/ssti-logo.png" class="center" width="450px" height="200px"/>
-	<h3>Hello: NAMEHERE</h3>
+	<h3>Hello: {{ name }}</h3>
     <h2>Try with /?name=YourName</h2>
 </body>
 </html>

--- a/owasp-top10-2017-apps/a1/sstype/src/server.py
+++ b/owasp-top10-2017-apps/a1/sstype/src/server.py
@@ -13,8 +13,7 @@ class MainHandler(tornado.web.RequestHandler):
 
     def get(self):
         name = self.get_argument('name', '')
-        template_data = tmpl.replace("NAMEHERE",name)
-        t = tornado.template.Template(template_data)
+        t = tornado.template.Template(tmpl)
         self.write(t.generate(name=name))
 
 application = tornado.web.Application([


### PR DESCRIPTION
## This solution refers to which of the apps?

A1 - SSType

## What did you do to mitigate the vulnerability?

It was removed the replace function and it was added a curly braces in index file.

## Did you test your changes? What commands did you run?

`curl http://localhost:10001/?name={{4*4}}`

`curl 'http://localhost:10001/?name=%7B%7B%27%27.__class__.__mro__[1].__subclasses__()[274](%27ls%27,%20shell=True,%20stdout=-1).communicate()%7D%7D'`