### PR TITLE
[A5][Tic-Tac-Toe] Fix the Broken Access Control vulnerabilities getting the username from JWT

### DIFF
--- a/owasp-top10-2017-apps/a5/tictactoe/src/app.js
+++ b/owasp-top10-2017-apps/a5/tictactoe/src/app.js
@@ -54,7 +54,7 @@ app.get('/healthcheck', (req, res) => {
 })
 
 app.post('/game', verifyJWT, async (req, res) => {
-    const user = req.body.user
+    const user = req.user
     const result = req.body.result
     let statistics = await db.getStatisticsFromUser(user)
     if (statistics === null){
@@ -119,7 +119,7 @@ app.post('/create', async (req, res) => {
 });
 
 app.get('/statistics/data', verifyJWT, async (req, res) => {
-    const user = req.query.user
+    const user = req.user
 
     let statistics = await db.getStatisticsFromUser(user)
     if (statistics === undefined){
@@ -188,6 +188,7 @@ function verifyJWT(req, res, next){
             return res
                 .sendFile(path.join(__dirname+'/public/views/error.html'))
         }
+        req.user = decoded.username
         next();
     });
 }

--- a/owasp-top10-2017-apps/a5/tictactoe/src/assets/js/sender.js
+++ b/owasp-top10-2017-apps/a5/tictactoe/src/assets/js/sender.js
@@ -2,7 +2,6 @@ function sendResult(result){
     const cookie = getCookie('tictacsession')
     const payload = JSON.parse(window.atob(cookie.split('.')[1])); 
     const form = {
-        user: payload.username,
         result: result,
     }
     const options = {

--- a/owasp-top10-2017-apps/a5/tictactoe/src/assets/js/statistics.js
+++ b/owasp-top10-2017-apps/a5/tictactoe/src/assets/js/statistics.js
@@ -4,7 +4,7 @@ window.onload = function() {
     }
     const cookie = getCookie('tictacsession')
     const payload = JSON.parse(window.atob(cookie.split('.')[1])); 
-    fetch(`http://localhost.:10005/statistics/data?user=${payload.username}`)
+    fetch(`http://localhost.:10005/statistics/data`)
         .then(resp => resp.json())
         .then(data => {
             renderChart(data)


### PR DESCRIPTION
## This solution refers to which of the apps?

A5 - Tic-Tac-Toe

## What did you do to mitigate the vulnerability?

Now, the app doesn't get the username from payload, but it get it from JWT token.

## Did you test your changes? What commands did you run?

If we try to execute the commands below, the server is going to ignore the username NonexistentUser in payload:

`curl -s 'GET' -b 'tictacsession=VALID_JWT_TOKEN' 'http://localhost.:10005/statistics/data?user=NonexistentUser'`

`curl -s 'POST' -b 'tictacsession=VALID_JWT_TOKEN' 'http://localhost.:10005/game' --data-binary 'user=NonexistentUser&result=win'`