### PR TITLE
[A7][Gossip World] Fix Cross-Site Scripting vulnerability removing the safe filter

### DIFF
--- a/owasp-top10-2017-apps/a7/gossip-world/app/templates/gossip.html
+++ b/owasp-top10-2017-apps/a7/gossip-world/app/templates/gossip.html
@@ -75,7 +75,7 @@
           <!-- Post Content -->
           <p class="lead">{{post[4]}}</p>
 
-          <p>{{post[1] | safe}}</p>
+          <p>{{post[1]}}</p>
 
           <hr>
 
@@ -113,7 +113,7 @@
             <img class="d-flex mr-3 rounded-circle" src="http://placehold.it/50x50" alt="">
             <div class="media-body">
               <h5 class="mt-0">{{comment[0]}}</h5>
-              {{comment[1] | safe}}
+              {{comment[1]}}
             </div>
           </div>
           {% endfor %}

--- a/owasp-top10-2017-apps/a7/gossip-world/app/templates/gossips.html
+++ b/owasp-top10-2017-apps/a7/gossip-world/app/templates/gossips.html
@@ -55,7 +55,7 @@
         <div class="col-md-8">
 
          {% if search %}
-         <h1>Results for {{search_text | safe}} </h1>
+         <h1>Results for {{search_text}} </h1>
          {% else %}
           <h1 class="my-4">Last gossips</h1>
          {% endif %}


### PR DESCRIPTION
## This solution refers to which of the apps?

A7 - Gossip World

## What did you do to mitigate the vulnerability?

How the application is using the Jinja2, we can remove the `|safe` filter to automatically escape the output.

## Did you test your changes? What commands did you run?

It was tested the username, search, title, subtitle, text and comment inputs with `<script>alert(1)</script>`.
