### PR TITLE
Add the environment variable POSTGRES_PASSWORD

### DIFF
--- a/owasp-top10-2017-apps/a9/cimentech/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a9/cimentech/deployments/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   drupal:
     image: drupal:7.57
     container_name: drupal
+    environment:
+      POSTGRES_PASSWORD: example
     build:
       context: ../
       dockerfile: deployments/drupal.Dockerfile
@@ -18,6 +20,8 @@ services:
   db:
     image: postgres:latest
     container_name: a9db
+    environment:
+      POSTGRES_PASSWORD: example
     ports:
       - 5432:5432
     networks: 


### PR DESCRIPTION
## Description 

The application doesn't execute and it is giving the error below:

```
Error: Database is uninitialized and superuser password is not specified.
    You must specify POSTGRES_PASSWORD to a non-empty value for the
    superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
 
    You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
    connections without a password. This is *not* recommended.
```

 This error is caused due a changed in the docker-library/postgres ([#589](https://github.com/docker-library/postgres/issues/580)).

## Proposed Changes

It was added the environment variable POSTGRES_PASSWORD in the docker-compose file to fix the error. The value of the password variable must be the same one in the `app/html/sites/default/settings.php` file.

## Testing

The install command should work properly: 

```
make install
```
