### PR TITLE
[A1][Mongection] Fix the NoSQL Injection using Mongoose Validation

### DIFF
--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -1,4 +1,5 @@
 const User = require('./models/user');
+const Login = require('./models/login');
 
 const register = async (user) => {
 
@@ -27,9 +28,9 @@ const register = async (user) => {
 const login = async (credentials) => {
 
     try {
-        const { email, password } = credentials;
+        const login = new Login(credentials);
 
-        const existsUser = await User.find({$and: [ { email: String(email)}, { password: String(password)} ]});
+        const existsUser = await User.find({$and: [ { email: login.email}, { password: login.password} ]});
 
         if(!existsUser) { return null;}
 

--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -30,7 +30,16 @@ const login = async (credentials) => {
     try {
         const login = new Login(credentials);
 
-        if (login.validateSync()) { return []; }
+        if (login.validateSync()) { 
+            // TODO: Log suspected attacks here.
+            // It's probably a good idea to log when a suspected attack occurs so that those monitoring
+            // the system can be aware.
+            // This section should only be entered if the username/password end up as `null`.
+            // This would only happen if they were:
+            //   a) not present in the request (unlikely, but possible)
+            //   b) not a string (likely attempted attack)
+            return []; 
+        }
 
         const existsUser = await User.find({$and: [ { email: login.email}, { password: login.password} ]});
 

--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -29,7 +29,7 @@ const login = async (credentials) => {
     try {
         const { email, password } = credentials;
 
-        const existsUser = await User.find({$and: [ { email: email}, { password: password} ]});
+        const existsUser = await User.find({$and: [ { email: email.toString()}, { password: password.toString()} ]});
 
         if(!existsUser) { return null;}
 

--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -29,7 +29,7 @@ const login = async (credentials) => {
     try {
         const { email, password } = credentials;
 
-        const existsUser = await User.find({$and: [ { email: email.toString()}, { password: password.toString()} ]});
+        const existsUser = await User.find({$and: [ { email: String(email)}, { password: String(password)} ]});
 
         if(!existsUser) { return null;}
 

--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -30,11 +30,11 @@ const login = async (credentials) => {
     try {
         const login = new Login(credentials);
 
-        if (login.validateSync()) { return null; }
+        if (login.validateSync()) { return []; }
 
         const existsUser = await User.find({$and: [ { email: login.email}, { password: login.password} ]});
 
-        if(!existsUser) { return null;}
+        if(!existsUser) { return [];}
 
         const returnUser = existsUser.map((user) => {
             return user.email

--- a/owasp-top10-2017-apps/a1/mongection/src/db.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/db.js
@@ -30,6 +30,8 @@ const login = async (credentials) => {
     try {
         const login = new Login(credentials);
 
+        if (login.validateSync()) { return null; }
+
         const existsUser = await User.find({$and: [ { email: login.email}, { password: login.password} ]});
 
         if(!existsUser) { return null;}

--- a/owasp-top10-2017-apps/a1/mongection/src/models/login.js
+++ b/owasp-top10-2017-apps/a1/mongection/src/models/login.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const loginSchema = new mongoose.Schema({
+    email: {
+        type: String,
+        required: true
+    },
+    password: {
+        type: String,
+        required: true
+    }
+});
+
+module.exports = mongoose.model('Login', loginSchema, 'login');


### PR DESCRIPTION
## This solution refers to which of the apps?

A1 - Mongection

## What did you do to mitigate the vulnerability?

I used a new `Login` Mongoose model to sanitize the inputs and added a second layer of protection by validating the model and short-circuiting the request to Mongo in the event of a validation error.  (There was already a PR up for the simple `String(password)` sanitization.)

## Did you test your changes? What commands did you run?

I tested by running through the same scenarios in the README.  I tried logging in with legit credentials, with special characters (to make sure they still worked), with incorrect credentials, and with a NoSQL injection payload.  I verified my fix in two ways:
1) By watching the response to make sure that incorrect credentials and invalid payloads returned a `Bad Credentials` response.
2) By inspecting the code while it was processing a NoSQL injection request.

In testing, I confirmed that the `Login` model does not accept anything but a `String` for its properties, resulting in them being `null` if a sub-query is passed in.  Additionally, `validateSync()` will return `undefined` if everything is good, or validation errors if the payload is not valid (e.g. `email` or `password` got set to `null`, or are incorrect type).

This solution is a bit overkill, as simply converting the `email` and `password` fields to strings (or checking if they are strings and short-circuiting if not) would have been sufficient, but I wanted to submit a novel solution.
