### PR TITLE
[A2] [saidajaula-monster] Fix broken authentication

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/db/init.sql
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/db/init.sql
@@ -7,4 +7,12 @@ CREATE TABLE tb_users(
     PRIMARY KEY(Id)
 );
 
+CREATE TABLE tb_auth_token(
+    Token VARCHAR(100),
+    Created_Date DATE,
+    Created_Time TIME,
+    User_ID VARCHAR(36) NOT NULL REFERENCES person(Id),
+    PRIMARY KEY(Token)
+);
+
 INSERT INTO tb_users (Id, Login, Hash_Senha, Dt_Cookie, Permissao) VALUES ('99016fcb-b4f7-48fe-9fed-5729265ce393', 'admin', '245a4cba5219e282178d46263a7e7cce1ed64006dc93aae9819645c6f6bc5c9d', NULL, 1);


### PR DESCRIPTION
## This solution refers to which of the apps?

A2 - Saidajaula Monster Fit

## What did you do to mitigate the vulnerability?

In this app, the feature that caused Broken Authentication was the previously known set of data used to create a SessionID cookie. If we create a random cookie, link it to the user and store it, the vulnerability is fixed. This code creates a pseudo-random string cookie every time an user logs in and then stores it in our database with a Foreign Key referencing the user. Now, when he navigates through URLs, the authentication and authorization is made by retrieving `sessionId`cookie and verifying the user referenced by the AuthToken object and then checking his permissions.

After these changes, it's almost impossible to generate an admin user `sessionID`, once it's generated by pseudo-random data. Also, if you try a random b64 string, it you return `Unauthenticated User` and redirect to login page.

Some improvements that might be done are:

- AuthToken expiration (allowed by `creation_date`  and `creation_time` attributes)
- Logout feature
- Limit of active tokens per user

## Did you test your changes? What commands did you run?

**Authentication Test**
1. Try to log in: `$ curl -i -L localhost:10002/login -F "username=<username>" -F "password=<password>" -X POST`
![image](https://user-images.githubusercontent.com/14843060/95987606-09ab2f00-0dfe-11eb-96aa-b31baf334d4c.png)

**Authorization test**
1. Create an user

2. Log user in: `$ curl -i -L localhost:10002/login -F "username=<username>" -F "password=<password>" -X POST`
![image](https://user-images.githubusercontent.com/14843060/95986559-994fde00-0dfc-11eb-8fd6-faf5fe8e5abd.png)

3. Copy `sessionId`

4. Check user by pasting `sessionId` into the given field and run: 
`$ curl -v --cookie "sessionId=<sessionId>" localhost:10002/user`
![image](https://user-images.githubusercontent.com/14843060/95986772-e16f0080-0dfc-11eb-945b-398b04deec8e.png)

5. Paste `sessionID` into the given field and run: 
`$ curl -v --cookie "sessionId=<sessionId>" http://localhost:10002/admin`

6. Application must return that user has no permission
![image](https://user-images.githubusercontent.com/14843060/95986834-f9df1b00-0dfc-11eb-9f79-e613f041b146.png)


If we turn our user an admin, he is able to access `localhost:10002/admin`:

![image](https://user-images.githubusercontent.com/14843060/95989858-2eed6c80-0e01-11eb-93e9-5d99e40b781c.png)

![image](https://user-images.githubusercontent.com/14843060/95990170-8e4b7c80-0e01-11eb-8086-9591fe0fae6d.png)


