### PR TITLE
Migrate A2 - Saidajaula Monster Fit app to python3

### DIFF
--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/model/password.py
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/model/password.py
@@ -17,7 +17,7 @@ class Password:
 
     def _make_hash(self, password):
         salt = self.guid + str(self.username)
-        dk = hashlib.pbkdf2_hmac('sha256', password, salt, 100000, 32)
+        dk = hashlib.pbkdf2_hmac('sha256', password.encode(), salt.encode(), 100000, 32)
         return str(binascii.hexlify(dk))
 
     def _compare_password(self, password_1, password_2):

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3
 WORKDIR /app
 ADD app/requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Hey There!

Opening this PR to migrate the app Saidajaula Monster Fit - A2 to python3.

Many of the fixes to this app will require libraries that do not support python2 anymore.

Only changed the Dockerfile, and had to update the hashing function on password.py (Appears to be a change in how the pbkdf2_hmac function works, no longer accepts strings but only bytes to hash)
