### PR TITLE
[A4 - ViniJr Blog] - Fix XML External Entities (XXE)

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,5 +1,7 @@
 <?php
-libxml_disable_entity_loader(true)
+if (\PHP_VERSION_ID < 80000) {
+    libxml_disable_entity_loader(true);
+}
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
 $dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);

--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,4 +1,5 @@
 <?php
+libxml_disable_entity_loader(true)
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
 $dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);


### PR DESCRIPTION
## This solution refers to which of the apps?

A4 - ViniJr Blog

## What did you do to mitigate the vulnerability?

To mitigate the problem we use the `libxml_disable_entity_loader` function to disable the ability to load external entities.