### PR TITLE
[FIX] ARMv8 Architecture Incompatibility

### DIFF
--- a/owasp-top10-2017-apps/a1/copy-n-paste/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a1/copy-n-paste/deployments/docker-compose.yml
@@ -1,7 +1,5 @@
-version: '3'
-
+version: '3.4'
 services:
-
     api:
         container_name: a1_api
         build:
@@ -22,10 +20,10 @@ services:
         external_links:
             - mysqldb:mysqldb
         restart: unless-stopped
-
+        
     mysqldb:
         container_name: mysqldb
-        image: mysql:5.7
+        image: mariadb:10.6.3
         ports:
           - "3307:3307"
         volumes:

--- a/owasp-top10-2017-apps/a10/games-irados/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a10/games-irados/deployments/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "2"
-
+version: "3.4"
 services:
    app:
       container_name: app-a10
@@ -26,7 +25,7 @@ services:
 
    mysqldb-a10:
       container_name: mysqldb-a10
-      image: mysql:5.7
+      image: mariadb:10.6.3
       ports:
          - "3307:3307"
       environment:

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
@@ -6,7 +6,7 @@ Flask-Cors==3.0.7
 itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.0
-mysqlclient==1.3.13
+mysqlclient==2.0.3
 six==1.11.0
 visitor==0.1.3
 Werkzeug==0.14.1

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.4"
 services:
   app:
     container_name: app-a2
@@ -24,7 +24,7 @@ services:
 
   db:
     container_name: db-a2
-    image: mysql:5.7
+    image: mariadb:10.6.3
     ports:
       - "3307:3307"
     environment:

--- a/owasp-top10-2017-apps/a5/tictactoe/README.md
+++ b/owasp-top10-2017-apps/a5/tictactoe/README.md
@@ -55,11 +55,11 @@ Now that you know the purpose of this app, what could go wrong? The following se
 
 ### 👀
 
-In order to better understand how the application handles its data, two users, `user1` and `user2`, can be created using the web interface by visiting [http://locahost.:10005/create](http://localhost:.10005/create) as exemplified below:
+In order to better understand how the application handles its data, two users, `user1` and `user2`, can be created using the web interface by visiting [http://locahost:10005/create](http://localhost:10005/create) as exemplified below:
 
 <p  align="center"><img  src="images/attack0.png"/></p>
 
-After logging in as `user1` and playing a few times, his/her statistics can be checked by visiting [http://localhost.:10005/statistics](http://localhost.:10005/statistics), as the following picture shows:
+After logging in as `user1` and playing a few times, his/her statistics can be checked by visiting [http://localhost:10005/statistics](http://localhost:10005/statistics), as the following picture shows:
 
 <p  align="center"><img  src="images/attack1.png"/></p>
 
@@ -67,7 +67,7 @@ To check how this information is being retrieved form the server, an attacker co
 
 <p  align="center"><img  src="images/attack3.png"/></p>
 
-You can replicate this GET by using the following curl command (use your own `tictacsession` token):  
+You can replicate this GET by using the following curl command (**use your own `tictacsession` token**):  
 
 ```sh
 curl -s 'GET' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDcyODg2LCJleHAiOjE1NjM0NzY0ODZ9.ESLVZ9bbfUbUdFBFRCzxGTPICuaEWdGLxrvWykEmhNk' 'http://localhost.:10005/statistics/data?user=user1'
@@ -82,7 +82,7 @@ curl -s 'GET' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmF
 As this AJAX request is being made passing the username as a URL parameter, it may indicate that only this parameter is being used to verify the permission to get the data. To check this, using the same `tictacsession`, an attacker could replace `user1` to another known user, as `user2` for example: 
 
 ```sh
-curl -s 'GET' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDcyODg2LCJleHAiOjE1NjM0NzY0ODZ9.ESLVZ9bbfUbUdFBFRCzxGTPICuaEWdGLxrvWykEmhNk' 'http://localhost.:10005/statistics/data?user=user2'
+curl -s 'GET' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDcyODg2LCJleHAiOjE1NjM0NzY0ODZ9.ESLVZ9bbfUbUdFBFRCzxGTPICuaEWdGLxrvWykEmhNk' 'http://localhost:10005/statistics/data?user=user2'
 ```
 
 ```json
@@ -106,7 +106,7 @@ This request is done by using two parameters, `user` and `result`, as shown bell
 To replicate this POST by using the curl command (use your own `tictacsession` token), you can type the following command: 
 
 ```sh
-curl -s 'POST' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM' 'http://localhost.:10005/game' --data-binary 'user=user1&result=win'
+curl -s 'POST' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM' 'http://localhost:10005/game' --data-binary 'user=user1&result=win'
 ```
 
 ```json
@@ -118,7 +118,7 @@ OK
 An attacker now could check if, by using another username into this request, he/she could modify other user's statistics. To do so, the parameter `user` is changed into another known user, as `user2` for example:
 
 ```sh
-curl -s 'POST' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM' 'http://localhost.:10005/game' --data-binary 'user=user2&result=win'
+curl -s 'POST' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM' 'http://localhost:10005/game' --data-binary 'user=user2&result=win'
 ```
 
 ```json
@@ -142,7 +142,7 @@ result="lose"
 tictacsession="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM"
 
 for i in `seq 1 $num`; do
-    curl -s 'POST' -b "tictacsession=$tictacsession" 'http://localhost.:10005/game' --data-binary "user=$user&result=$result"
+    curl -s 'POST' -b "tictacsession=$tictacsession" 'http://localhost:10005/game' --data-binary "user=$user&result=$result"
 done
 ```
 
@@ -159,7 +159,7 @@ OKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOKOK
 To check if this attack indeed worked, the malicious user could exploit the previous vulnerability to check `user2` statistics using the following command:
 
 ```sh
-curl -s 'GET' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM' 'http://localhost.:10005/statistics/data?user=user2'
+curl -s 'GET' -b 'tictacsession=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIxIiwiaWF0IjoxNTYzNDc5MzIxLCJleHAiOjE1NjM0ODI5MjF9.SRVz09ZebGa875MilaV2bj4tjAdTWA14JTuArnUDOZM' 'http://localhost:10005/statistics/data?user=user2'
 ```
 
 ```json

--- a/owasp-top10-2017-apps/a5/tictactoe/deployments/Dockerfile
+++ b/owasp-top10-2017-apps/a5/tictactoe/deployments/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:8.15.1-alpine
+FROM node:10.24.1-alpine
 WORKDIR /
 ADD ./ /
 RUN apk update && \
     npm install package.json && \
-    npm install -g gulp@3.9.1
+    npm install -g gulp
 CMD gulp && node src/app.js

--- a/owasp-top10-2017-apps/a5/tictactoe/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a5/tictactoe/deployments/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3'
+version: '3.4'
 
 services:
-
     api:
         container_name: a5_tictactoe
         build:
@@ -21,7 +20,7 @@ services:
 
     mysqldb:
         container_name: mysqldb
-        image: mysql:5.7
+        image: mariadb:10.6.3
         ports:
           - "3307:3306"
         volumes:

--- a/owasp-top10-2017-apps/a5/tictactoe/package.json
+++ b/owasp-top10-2017-apps/a5/tictactoe/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
-    "gulp": "3.9.1",
+    "gulp": "^3.9.1",
     "gulp-babel": "^8.0.0",
     "gulp-concat": "2.6.1",
     "gulp-htmlmin": "4.0.0",

--- a/owasp-top10-2017-apps/a5/tictactoe/src/app.js
+++ b/owasp-top10-2017-apps/a5/tictactoe/src/app.js
@@ -21,7 +21,7 @@ app.use(bodyParser.urlencoded({extended: true}))
 app.use(express.static(__dirname + '/public'));
 
 app.use(function(req, res, next) {
-    res.header("Access-Control-Allow-Origin", "http://localhost.:10005");
+    res.header("Access-Control-Allow-Origin", "http://localhost:10005");
     next();
   });
 

--- a/owasp-top10-2017-apps/a5/tictactoe/src/db.js
+++ b/owasp-top10-2017-apps/a5/tictactoe/src/db.js
@@ -26,8 +26,12 @@ function execQuery(query, fields){
 function addUser(username, password, salt){
     const query = 'INSERT INTO User(username, password, salt) VALUES(?, ?, ?)'
     const parameters = [username, password, salt]
-
-    execQuery(query, parameters)
+    
+    try {
+        execQuery(query, parameters)
+    } catch(e) {
+        console.log(e.message)
+    }
 }
 
 function getPasswordSalt(username){
@@ -93,7 +97,11 @@ function updateUserStatistics(username, statistics){
                    SET games = ?, wins = ?, ties = ?, loses = ?
                    WHERE username = ?`
     const parameters = [statistics.games, statistics.wins, statistics.ties, statistics.loses, username]
-    execQuery(query, parameters)
+    try {
+        execQuery(query, parameters)
+    } catch(e) {
+        console.log(e.message)
+    }
 }
 function upsertUserStatistics(username, statistics){
     const query = `INSERT INTO Statistics(username, games, wins, ties, loses)
@@ -109,7 +117,11 @@ function upsertUserStatistics(username, statistics){
         statistics.wins, 
         statistics.ties, 
         statistics.loses]
-    execQuery(query, parameters)
+    try {
+        execQuery(query, parameters)
+    } catch(e) {
+        console.log(e.message)
+    }
 }
 
 function createTables(){

--- a/owasp-top10-2017-apps/a6/misconfig-wordpress/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a6/misconfig-wordpress/deployments/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3.3'
+version: '3.4'
 
 services:
    db:
     container_name: a6db
-    image: secdevlabs/a6-the-mistery:db-version-2
+    image: mariadb:10.6.3
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress

--- a/owasp-top10-2017-apps/a6/stegonography/app/node_modules/.bin/semver
+++ b/owasp-top10-2017-apps/a6/stegonography/app/node_modules/.bin/semver
@@ -1,1 +1,0 @@
-../semver/bin/semver

--- a/owasp-top10-2017-apps/a7/gossip-world/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a7/gossip-world/deployments/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.4"
 
 services:
   app:
@@ -26,7 +26,7 @@ services:
     
   mysqldb-a7:
     container_name: mysqldb-a7
-    image: mysql:5.7
+    image: mariadb:10.6.3
     ports:
       - "3307:3307"
     environment:

--- a/owasp-top10-2017-apps/a7/streaming/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a7/streaming/deployments/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3'
+version: '3.4'
 services:
   db:
-    image: mysql:5.7
+    image: mariadb:10.6.3
     container_name: mysql-a7-streaming
     restart: always
     environment:


### PR DESCRIPTION
## Problem

Some applications in OWASP-top10-2017-app have incompatibility dependencies at the build stage when we using an ARMv8 architecture computer, e.g., Macbook with Apple M1, making it impossible to run the exercises labs on a computer using this architecture.

## Update Note

| Application | Update |
| --- | --- | 
| [CopyNPaste API](owasp-top10-2017-apps/a1/copy-n-paste) | Changed MySQL database to MariaDB database in version 10.6.3 |
| [Saidajaula Monster Fit](owasp-top10-2017-apps/a2/saidajaula-monster) | Changed MySQL database to MariaDB database in version 10.6.3 |
| [Tic-Tac-Toe](owasp-top10-2017-apps/a5/tictactoe) | Changed MySQL database to MariaDB database in version 10.6.3 and NodeJS version 8.15.1 to version 10.24.1 |
| [Vulnerable Wordpress Misconfig](owasp-top10-2017-apps/a6/misconfig-wordpress) | Changed the custom database image to MariaDB database in version 10.6.3 | 
| [Gossip World](owasp-top10-2017-apps/a7/gossip-world) | Changed MySQL database to MariaDB database in version 10.6.3  |
| [GamesIrados.com](owasp-top10-2017-apps/a10/games-irados) | Changed MySQL database to MariaDB database in version 10.6.3 |