### PR TITLE
[A4 - ViniJR Blog] XML External Entity vulnerability

### DIFF
--- a/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
+++ b/owasp-top10-2017-apps/a4/vinijr-blog/app/contact.php
@@ -1,4 +1,5 @@
 <?php
+libxml_disable_entity_loader(true);
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
 $dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);


### PR DESCRIPTION
## This solution refers to which of the apps?

A4 - ViniJR Blog

## What did you do to mitigate the vulnerability?

Using libxml_disable_entity_loader function passing “true” as parameter disabled loading of external entities. From PHP 8, this function has been deprecated and its use can be conditioned by the value of PHP_VERSION_ID (< 80000) or LIBXML_VERSION (< 20900) variables.

## Did you test your changes? What commands did you run?

The extraction of sensitive information by XXE injection, as described in "Attack Narrative" section were rerun after the vulnerability was fixed, with positive results for application's security.
