### PR TITLE
[A9 - Cimentech] Remote Code Execution vulnerability

### DIFF
--- a/owasp-top10-2017-apps/a9/cimentech/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a9/cimentech/deployments/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   drupal:
-    image: drupal:7.57
+    image: drupal:7.82
     container_name: drupal
     environment:
       POSTGRES_PASSWORD: example


### PR DESCRIPTION
## This solution refers to which of the apps?

A9 - Cimentech

## What did you do to mitigate the vulnerability?

According to the [Drupal website](https://www.drupal.org/project/drupal), the currently recommended version for sites already running Drupal 7 is 7.82, which will be supported until November 2022. As recommended, Drupal version 7.57 has been updated to 7.82.

## Did you test your changes? What commands did you run?

Remote Code Execution (RCE) using an exploit, as described in the "Attack Narrative" section were rerun after the vulnerability was fixed, through the Drupal update. The retry got the return message: "Target is NOT exploitable".
