### PR TITLE
[A7 - Streaming] Cross-Site Scripting vulnerability

### DIFF
--- a/owasp-top10-2017-apps/a7/streaming/app/frontend/src/app/lives/play/play.component.ts
+++ b/owasp-top10-2017-apps/a7/streaming/app/frontend/src/app/lives/play/play.component.ts
@@ -1,9 +1,10 @@
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, SecurityContext } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { UserUtil } from 'src/app/user/user-utils';
 import { LiveService } from '../lives.service';
 import { Message } from '../message';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-play',
@@ -15,7 +16,7 @@ export class PlayComponent implements OnInit {
   #selectedLive;
   #message;
 
-  constructor(private router: Router, private activatedRoute: ActivatedRoute, private liveService: LiveService) {
+  constructor(private router: Router, private activatedRoute: ActivatedRoute, private liveService: LiveService, private domSanitizer: DomSanitizer) {
     this.#message = "";
 
     setInterval(() => {
@@ -120,7 +121,7 @@ export class PlayComponent implements OnInit {
 
     newMessageBox.appendChild(labelUserMessage);
 
-    contentMessage.innerHTML = message.content;
+    contentMessage.innerHTML = this.domSanitizer.sanitize(SecurityContext.HTML, message.content);
     newMessageBox.appendChild(contentMessage);
 
     return newMessageBox;


### PR DESCRIPTION
## This solution refers to which of the apps?

A7 - Streaming

## What did you do to mitigate the vulnerability?

According to [Angular documentation](https://angular.io/guide/security), sanitization is performed in certain security contexts. The assignment of contentMessage using innerHTML is performed in HTML context so that the message.content value is read as HTML. This is enough to neutralize XSS attacks using <script>...</script>, in SCRIPT context. To neutralize XSS attacks using \<img onerror="..."\>, it was necessary to add sanitization for contentMessage assignment performed in HTML security context using DOMSanitizer.

## Did you test your changes? What commands did you run?

The script execution attempt in message input field described in the "Attack Narrative" section were rerun after the vulnerability was fixed. It effect were neutralized as positive result for application's security.
