### PR TITLE
Resolve #524 - Add Support to ARMv8 Architecture (M1 Macbooks)

### DIFF
--- a/owasp-top10-2017-apps/a1/copy-n-paste/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a1/copy-n-paste/deployments/docker-compose.yml
@@ -1,7 +1,5 @@
-version: '3'
-
+version: '3.4'
 services:
-
     api:
         container_name: a1_api
         build:
@@ -22,10 +20,10 @@ services:
         external_links:
             - mysqldb:mysqldb
         restart: unless-stopped
-
+        
     mysqldb:
         container_name: mysqldb
-        image: mysql:5.7
+        image: mariadb:10.6.3
         ports:
           - "3307:3307"
         volumes:

--- a/owasp-top10-2017-apps/a10/games-irados/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a10/games-irados/deployments/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "2"
-
+version: "3.4"
 services:
    app:
       container_name: app-a10
@@ -26,7 +25,7 @@ services:
 
    mysqldb-a10:
       container_name: mysqldb-a10
-      image: mysql:5.7
+      image: mariadb:10.6.3
       ports:
          - "3307:3307"
       environment:

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/app/requirements.txt
@@ -6,7 +6,7 @@ Flask-Cors==3.0.7
 itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.0
-mysqlclient==1.3.13
+mysqlclient==2.0.3
 six==1.11.0
 visitor==0.1.3
 Werkzeug==0.14.1

--- a/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a2/saidajaula-monster/deployments/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.4"
 services:
   app:
     container_name: app-a2
@@ -24,7 +24,7 @@ services:
 
   db:
     container_name: db-a2
-    image: mysql:5.7
+    image: mariadb:10.6.3
     ports:
       - "3307:3307"
     environment:

--- a/owasp-top10-2017-apps/a6/misconfig-wordpress/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a6/misconfig-wordpress/deployments/docker-compose.yml
@@ -1,9 +1,8 @@
-version: '3.3'
-
+version: '3.4'
 services:
    db:
     container_name: a6db
-    image: secdevlabs/a6-the-mistery:db-version-2
+    image: mariadb:10.6.3
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress

--- a/owasp-top10-2017-apps/a7/gossip-world/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a7/gossip-world/deployments/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "2"
-
+version: "3.4"
 services:
   app:
     container_name: app-a7 
@@ -26,7 +25,7 @@ services:
     
   mysqldb-a7:
     container_name: mysqldb-a7
-    image: mysql:5.7
+    image: mariadb:10.6.3
     ports:
       - "3307:3307"
     environment:

--- a/owasp-top10-2017-apps/a7/streaming/deployments/docker-compose.yml
+++ b/owasp-top10-2017-apps/a7/streaming/deployments/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3'
+version: '3.4'
 services:
   db:
-    image: mysql:5.7
+    image: mariadb:10.6.3
     container_name: mysql-a7-streaming
     restart: always
     environment:


### PR DESCRIPTION
## This solution refers to which of the apps?

| Application | Update |
| --- | --- | 
| [CopyNPaste API](owasp-top10-2017-apps/a1/copy-n-paste) | Changed MySQL database to MariaDB database in version 10.6.3 |
| [Saidajaula Monster Fit](owasp-top10-2017-apps/a2/saidajaula-monster) | Changed MySQL database to MariaDB database in version 10.6.3 |
| [Vulnerable Wordpress Misconfig](owasp-top10-2017-apps/a6/misconfig-wordpress) | Changed the custom database image to MariaDB database in version 10.6.3 | 
| [Gossip World](owasp-top10-2017-apps/a7/gossip-world) | Changed MySQL database to MariaDB database in version 10.6.3  |
| [GamesIrados.com](owasp-top10-2017-apps/a10/games-irados) | Changed MySQL database to MariaDB database in version 10.6.3 |

## What did you do to mitigate the vulnerability?

Changed the version of docker images for some applications that were having problems running on ARM architecture.

