### PR TITLE
a5_vinijr_blog

### DIFF
--- a/owasp-top10-2021-apps/a5/vinijr-blog/app/contact.php
+++ b/owasp-top10-2021-apps/a5/vinijr-blog/app/contact.php
@@ -1,7 +1,7 @@
 <?php
 $xmlfile = file_get_contents('php://input');
 $dom = new DOMDocument();
-$dom->loadXML($xmlfile, LIBXML_NOENT | LIBXML_DTDLOAD);
+$dom->loadXML($xmlfile);
 $contact = simplexml_import_dom($dom);
 $name = $contact->name;
 $email = $contact->email;


### PR DESCRIPTION
## This solution refers to which of the apps?

A5 Vinijr blog 

A/M# - App's name here

## What did you do to mitigate the vulnerability?

From contact.php file, remove LIBXML_NOENT | LIBXML_DTDLOAD because this function has been deprecated. Is preferable to disable the libs to suppress the loading of external entities (XXE).


A clear and concise description of what you did. Keep in mind that, if your solution is accepted, this PR will be listed as possible solutions, so do your best to explain it clearly! 😁

Images are not necessary but are greatly appreciated! 📸

## Did you test your changes? What commands did you run?

No, is this exercise was simple. Only need to pay attention to the file (contact.php) directly, and the other lines of the file are normal, only this libs is not indicated to use like is writing at PHP official document. <php.net/manual/pt_BR/example.xml-external-entity.php>

A good place to start would be trying to reproduce the attack narrative and not being able to successfully exploit the app anymore.
