### PR TITLE
Pin Postgres version for a6-cimentech

### DIFF
--- a/owasp-top10-2021-apps/a6/cimentech/deployments/docker-compose.yml
+++ b/owasp-top10-2021-apps/a6/cimentech/deployments/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - a9_net
 
   db:
-    image: postgres:latest
+    image: postgres:10.5
     container_name: a9db
     environment:
       POSTGRES_PASSWORD: example


### PR DESCRIPTION
Using `postgres:latest` was breaking the build, since we are using a deprecated version of `drupal`