### PR TITLE
feat: create make compose-down script

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,9 +23,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2016-mobile/m2/cool_games/server/Makefile
+++ b/owasp-top10-2016-mobile/m2/cool_games/server/Makefile
@@ -24,9 +24,11 @@ PORT := 11002
 install: env compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2016-mobile/m4/note-box/server/Makefile
+++ b/owasp-top10-2016-mobile/m4/note-box/server/Makefile
@@ -24,9 +24,11 @@ PORT := 11004
 install: env compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2016-mobile/m5/panda_zap/server/Makefile
+++ b/owasp-top10-2016-mobile/m5/panda_zap/server/Makefile
@@ -24,9 +24,11 @@ PORT := 11005
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a1/camplake-api/Makefile
+++ b/owasp-top10-2021-apps/a1/camplake-api/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 10
 install: generate-passwords compose
 
 ## Runs project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Generates passwords and set them as environment variables
 generate-passwords:

--- a/owasp-top10-2021-apps/a1/ecommerce-api/Makefile
+++ b/owasp-top10-2021-apps/a1/ecommerce-api/Makefile
@@ -46,9 +46,11 @@ lint:
 	$(GOLINT) $(shell $(GO) list ./...)
 
 ## Runs project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Generates passwords and set them as environment variables
 generate-passwords:

--- a/owasp-top10-2021-apps/a1/tictactoe/Makefile
+++ b/owasp-top10-2021-apps/a1/tictactoe/Makefile
@@ -14,9 +14,11 @@ PORT := 10005
 install: env compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Generate new environment variables for Stegonography app
 env:

--- a/owasp-top10-2021-apps/a2/snake-pro/Makefile
+++ b/owasp-top10-2021-apps/a2/snake-pro/Makefile
@@ -22,9 +22,11 @@ COLOR_RED = \033[31m
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a3/comment-killer/Makefile
+++ b/owasp-top10-2021-apps/a3/comment-killer/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg
 
 ## Runs project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Deploys project and view docker logs
 deploy: compose

--- a/owasp-top10-2021-apps/a3/copy-n-paste/Makefile
+++ b/owasp-top10-2021-apps/a3/copy-n-paste/Makefile
@@ -20,9 +20,11 @@ SLEEPUNTILAPPSTARTS := 45
 test: go test ./...
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 exploit:
 	chmod +x deployments/exploit.sh

--- a/owasp-top10-2021-apps/a3/gossip-world/Makefile
+++ b/owasp-top10-2021-apps/a3/gossip-world/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg 
 
 ## Runs project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Deploys project and view docker logs
 deploy: compose

--- a/owasp-top10-2021-apps/a3/mongection/Makefile
+++ b/owasp-top10-2021-apps/a3/mongection/Makefile
@@ -14,9 +14,11 @@ PORT := 10001
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a3/sstype/Makefile
+++ b/owasp-top10-2021-apps/a3/sstype/Makefile
@@ -14,9 +14,11 @@ PORT := 10001
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a3/streaming/Makefile
+++ b/owasp-top10-2021-apps/a3/streaming/Makefile
@@ -23,9 +23,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a5/misconfig-wordpress/Makefile
+++ b/owasp-top10-2021-apps/a5/misconfig-wordpress/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 60
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a5/stegonography/Makefile
+++ b/owasp-top10-2021-apps/a5/stegonography/Makefile
@@ -14,9 +14,11 @@ PORT := 10006
 install: env compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Generate new environment variables for Stegonography app
 env:

--- a/owasp-top10-2021-apps/a5/vinijr-blog/Makefile
+++ b/owasp-top10-2021-apps/a5/vinijr-blog/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 5
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a6/cimentech/Makefile
+++ b/owasp-top10-2021-apps/a6/cimentech/Makefile
@@ -14,9 +14,11 @@ PORT := 80
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a6/golden-hat/Makefile
+++ b/owasp-top10-2021-apps/a6/golden-hat/Makefile
@@ -23,9 +23,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a7/insecure-go-project/Makefile
+++ b/owasp-top10-2021-apps/a7/insecure-go-project/Makefile
@@ -24,9 +24,11 @@ PORT := 10002
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a7/saidajaula-monster/Makefile
+++ b/owasp-top10-2021-apps/a7/saidajaula-monster/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a8/amarelo-designs/Makefile
+++ b/owasp-top10-2021-apps/a8/amarelo-designs/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 10
 install: compose msg
 
 ## Composes project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a9/games-irados/Makefile
+++ b/owasp-top10-2021-apps/a9/games-irados/Makefile
@@ -15,9 +15,11 @@ SLEEPUNTILAPPSTARTS := 45
 install: compose msg
 
 ## Run project using docker-compose
-compose:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+compose: compose-down
 	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+
+compose-down:
+	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:


### PR DESCRIPTION
Create a script in `Makefile` to help users take down your applications.

Now you can install your application and remove it before usage:
```bash
$ make install
SecDevLabs: 👀  Your app is starting!
SecDevLabs: 👀  Your app is still starting... (----*---)
SecDevLabs: 🔥  AX - XX is now running at http://localhost:X
...
$ make compose-down
```