### PR TITLE
feat: add project name to limit compose scope

### DIFF
--- a/owasp-top10-2016-mobile/m2/cool_games/server/Makefile
+++ b/owasp-top10-2016-mobile/m2/cool_games/server/Makefile
@@ -25,10 +25,11 @@ install: env compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2016-mobile/m4/note-box/server/Makefile
+++ b/owasp-top10-2016-mobile/m4/note-box/server/Makefile
@@ -25,10 +25,11 @@ install: env compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2016-mobile/m5/panda_zap/server/Makefile
+++ b/owasp-top10-2016-mobile/m5/panda_zap/server/Makefile
@@ -25,10 +25,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f docker-compose.yml up -d --build --force-recreate
+	docker-compose -f docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f docker-compose.yml down -v --remove-orphans
+	docker-compose -f docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a1/camplake-api/Makefile
+++ b/owasp-top10-2021-apps/a1/camplake-api/Makefile
@@ -16,10 +16,11 @@ install: generate-passwords compose
 
 ## Runs project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Generates passwords and set them as environment variables
 generate-passwords:

--- a/owasp-top10-2021-apps/a1/ecommerce-api/Makefile
+++ b/owasp-top10-2021-apps/a1/ecommerce-api/Makefile
@@ -47,10 +47,11 @@ lint:
 
 ## Runs project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Generates passwords and set them as environment variables
 generate-passwords:

--- a/owasp-top10-2021-apps/a1/ecommerce-api/deployments/docker-compose.yml
+++ b/owasp-top10-2021-apps/a1/ecommerce-api/deployments/docker-compose.yml
@@ -10,8 +10,6 @@ services:
             MONGO_DATABASE_NAME: DB
             MONGO_PORT: 27017
             MONGO_TIMEOUT: 60
-            MONGO_PORT: 27017
-            MONGO_TIMEOUT: 60
         env_file:
             - dockers.env
         build:

--- a/owasp-top10-2021-apps/a1/tictactoe/Makefile
+++ b/owasp-top10-2021-apps/a1/tictactoe/Makefile
@@ -15,10 +15,11 @@ install: env compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Generate new environment variables for Stegonography app
 env:

--- a/owasp-top10-2021-apps/a2/snake-pro/Makefile
+++ b/owasp-top10-2021-apps/a2/snake-pro/Makefile
@@ -23,10 +23,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a3/comment-killer/Makefile
+++ b/owasp-top10-2021-apps/a3/comment-killer/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Runs project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Deploys project and view docker logs
 deploy: compose

--- a/owasp-top10-2021-apps/a3/copy-n-paste/Makefile
+++ b/owasp-top10-2021-apps/a3/copy-n-paste/Makefile
@@ -21,10 +21,11 @@ test: go test ./...
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 exploit:
 	chmod +x deployments/exploit.sh

--- a/owasp-top10-2021-apps/a3/gossip-world/Makefile
+++ b/owasp-top10-2021-apps/a3/gossip-world/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Runs project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Deploys project and view docker logs
 deploy: compose

--- a/owasp-top10-2021-apps/a3/mongection/Makefile
+++ b/owasp-top10-2021-apps/a3/mongection/Makefile
@@ -15,10 +15,11 @@ install: compose msg
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a3/sstype/Makefile
+++ b/owasp-top10-2021-apps/a3/sstype/Makefile
@@ -15,10 +15,11 @@ install: compose msg
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a3/streaming/Makefile
+++ b/owasp-top10-2021-apps/a3/streaming/Makefile
@@ -24,10 +24,11 @@ install: compose msg
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a5/misconfig-wordpress/Makefile
+++ b/owasp-top10-2021-apps/a5/misconfig-wordpress/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a5/stegonography/Makefile
+++ b/owasp-top10-2021-apps/a5/stegonography/Makefile
@@ -15,10 +15,11 @@ install: env compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Generate new environment variables for Stegonography app
 env:

--- a/owasp-top10-2021-apps/a5/vinijr-blog/Makefile
+++ b/owasp-top10-2021-apps/a5/vinijr-blog/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a6/cimentech/Makefile
+++ b/owasp-top10-2021-apps/a6/cimentech/Makefile
@@ -15,10 +15,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a6/golden-hat/Makefile
+++ b/owasp-top10-2021-apps/a6/golden-hat/Makefile
@@ -24,10 +24,11 @@ install: compose msg
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase - You can find that the check-init.sh script is also in the docs folder.
 msg:

--- a/owasp-top10-2021-apps/a7/insecure-go-project/Makefile
+++ b/owasp-top10-2021-apps/a7/insecure-go-project/Makefile
@@ -25,10 +25,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a7/saidajaula-monster/Makefile
+++ b/owasp-top10-2021-apps/a7/saidajaula-monster/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a8/amarelo-designs/Makefile
+++ b/owasp-top10-2021-apps/a8/amarelo-designs/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Composes project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:

--- a/owasp-top10-2021-apps/a9/games-irados/Makefile
+++ b/owasp-top10-2021-apps/a9/games-irados/Makefile
@@ -16,10 +16,11 @@ install: compose msg
 
 ## Run project using docker-compose
 compose: compose-down
-	docker-compose -f deployments/docker-compose.yml up -d --build --force-recreate
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs up -d --build --force-recreate
 
+## Down project using docker-compose
 compose-down:
-	docker-compose -f deployments/docker-compose.yml down -v --remove-orphans
+	docker-compose -f deployments/docker-compose.yml -p secDevLabs down -v --remove-orphans
 
 ## Prints initialization message after compose phase
 msg:


### PR DESCRIPTION
Add `-p secDevLabs`to `docker-compose`commands to limit scope and not conflict with no related local containers.

Now you can `make install` without worrying about affecting other projects.

#561 