### PR TITLE
fix: change version drupal

### DIFF
--- a/owasp-top10-2021-apps/a6/cimentech/deployments/docker-compose.yml
+++ b/owasp-top10-2021-apps/a6/cimentech/deployments/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   drupal:
-    image: drupal:7.57
+    image: drupal:7.89
     container_name: drupal
     environment:
       POSTGRES_PASSWORD: example


### PR DESCRIPTION
## This solution refers to which of the apps?

A6 - cimentech

## What did you do to mitigate the vulnerability?

I did a google search and found that Drupal according to the official website, the currently recommended version for websites is 7.82 which has fixed security vulnerabilities.
Link:
(https://www.drupal.org/project/drupal/releases/7.82)

## Did you test your changes? What commands did you run?

I followed the step by step of read.me, after changing the version the test returned the message "The destination is NOT exploitable"
