### PR TITLE
[A1] Broken Access Control - Vulnerable Ecommerce API

### DIFF
--- a/owasp-top10-2021-apps/a1/ecommerce-api/app/handlers/handlers.go
+++ b/owasp-top10-2021-apps/a1/ecommerce-api/app/handlers/handlers.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/globocom/secDevLabs/owasp-top10-2021-apps/a1/ecommerce-api/app/db"
 	"github.com/labstack/echo"
 )
@@ -16,6 +18,31 @@ func HealthCheck(c echo.Context) error {
 // GetTicket returns the userID ticket.
 func GetTicket(c echo.Context) error {
 	id := c.Param("id")
+	cookie, err := c.Cookie("sessionIDa5")
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"result": "error", "details": "Error finding cookie."})
+	}
+
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != "HS256" {
+			return nil, fmt.Errorf("unexpected jwt signing method=%v", t.Header["alg"])
+		}
+		return []byte("secret"), nil
+	}
+
+	// claims are of type `jwt.MapClaims` when token is created with `jwt.Parse`
+	token, err := jwt.Parse(cookie.Value, keyFunc)
+	if err != nil {
+		return err
+	}
+	if !token.Valid {
+		return errors.New("invalid token")
+	}
+	claims := token.Claims.(jwt.MapClaims)
+	if claims["id"] != id {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"result": "error", "details": "User not authorized!"})
+	}
+
 	userDataQuery := map[string]interface{}{"userID": id}
 	userDataResult, err := db.GetUserData(userDataQuery)
 	if err != nil {

--- a/owasp-top10-2021-apps/a1/ecommerce-api/app/handlers/session.go
+++ b/owasp-top10-2021-apps/a1/ecommerce-api/app/handlers/session.go
@@ -67,6 +67,7 @@ func Login(c echo.Context) error {
 	// Set claims
 	claims := token.Claims.(jwt.MapClaims)
 	claims["name"] = userDataResult.Username
+	claims["id"] = userDataResult.UserID
 	claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	// Generate encoded token and send it as response.


### PR DESCRIPTION
## This solution refers to which of the apps?

A1 - [Vulnerable eCommerce API](https://github.com/globocom/secDevLabs/tree/master/owasp-top10-2021-apps/a1/ecommerce-api)

## What did you do to mitigate the vulnerability?

Was implemented a token validation in the route `/ticket`.

## Did you test your changes? What commands did you run?

- Create two users.
- Try to create jwt token with diferent UserID.
- Get http status code 401