### PR TITLE
fix: implement parameterazed query avoinding sqli

### DIFF
--- a/owasp-top10-2021-apps/a3/copy-n-paste/app/util/db.go
+++ b/owasp-top10-2021-apps/a3/copy-n-paste/app/util/db.go
@@ -15,7 +15,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-//OpenDBConnection establish a connection with the MySQL DB.
+// OpenDBConnection establish a connection with the MySQL DB.
 func OpenDBConnection() (*sql.DB, error) {
 	connstr := fmt.Sprintf(
 		"%s:%s@tcp(%s:%s)/%s",
@@ -34,7 +34,7 @@ func OpenDBConnection() (*sql.DB, error) {
 	return dbConn, nil
 }
 
-//AuthenticateUser is the function that checks if the given user and password are valid or not
+// AuthenticateUser is the function that checks if the given user and password are valid or not
 func AuthenticateUser(user string, pass string) (bool, error) {
 	if user == "" || pass == "" {
 		return false, errors.New("All fields are required")
@@ -46,8 +46,12 @@ func AuthenticateUser(user string, pass string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("select * from Users where username = '" + user + "'")
-	rows, err := dbConn.Query(query)
+	query := `
+  SELECT * 
+  FROM Users 
+  WHERE username = $1`
+
+	rows, err := dbConn.Query(query, user)
 	if err != nil {
 		return false, err
 	}
@@ -65,7 +69,7 @@ func AuthenticateUser(user string, pass string) (bool, error) {
 	return false, nil
 }
 
-//NewUser registers a new user to the db
+// NewUser registers a new user to the db
 func NewUser(user string, pass string, passcheck string) (bool, error) {
 	if user == "" || pass == "" || passcheck == "" {
 		return false, errors.New("All fields are required")
@@ -88,8 +92,11 @@ func NewUser(user string, pass string, passcheck string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("insert into Users (username, password) values ('" + user + "', '" + passHash + "')")
-	rows, err := dbConn.Query(query)
+	query := `
+  INSERT INTO Users (username, password)
+  VALUES ($1, $2)`
+
+	rows, err := dbConn.Query(query, user, passHash)
 	if err != nil {
 		return false, err
 	}
@@ -99,7 +106,7 @@ func NewUser(user string, pass string, passcheck string) (bool, error) {
 	return true, nil //user created
 }
 
-//CheckIfUserExists checks if there is an user with the given username on db
+// CheckIfUserExists checks if there is an user with the given username on db
 func CheckIfUserExists(username string) (bool, error) {
 
 	dbConn, err := OpenDBConnection()
@@ -108,8 +115,12 @@ func CheckIfUserExists(username string) (bool, error) {
 	}
 	defer dbConn.Close()
 
-	query := fmt.Sprint("select username from Users where username = '" + username + "'")
-	rows, err := dbConn.Query(query)
+	query := `
+  SELECT username 
+  FROM Users 
+  WHERE username = $1`
+
+	rows, err := dbConn.Query(query, username)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## This solution refers to which of the apps?

A/M# - copy-n-paste

## What did you do to mitigate the vulnerability?

Rewrote SQL queries to support parameters instead of concatenated strings


## Did you test your changes? What commands did you run?
yes, I used slqmap after capturing the http request on the application's login page
```
sqlmap -r login.req  --batch
```
