### PR TITLE
[A3] fix template injection

### DIFF
--- a/owasp-top10-2021-apps/a3/sstype/src/public/index.html
+++ b/owasp-top10-2021-apps/a3/sstype/src/public/index.html
@@ -28,7 +28,7 @@ background: linear-gradient(90deg, rgba(4,0,57,1) 0%, rgba(4,5,41,1) 46%, rgba(2
     <br>
     <br>
     <img style="align-self: center" src="images/ssti-logo.png" class="center" width="450px" height="200px"/>
-	<h3>Hello: NAMEHERE</h3>
+	<h3>Hello: {{name}}</h3>
     <h2>Try with /?name=YourName</h2>
 </body>
 </html>

--- a/owasp-top10-2021-apps/a3/sstype/src/server.py
+++ b/owasp-top10-2021-apps/a3/sstype/src/server.py
@@ -1,21 +1,14 @@
-import tornado.template
-import tornado.ioloop
-import tornado.web
 import os
+import tornado
 
-TEMPLATE = open(os.path.join(os.path.dirname(__file__)) + "/public/index.html", 'r').readlines()
-
-tmpl = ''
-for t in TEMPLATE:
-    	tmpl += t
 
 class MainHandler(tornado.web.RequestHandler):
 
     def get(self):
         name = self.get_argument('name', '')
-        template_data = tmpl.replace("NAMEHERE",name)
-        t = tornado.template.Template(template_data)
-        self.write(t.generate(name=name))
+        escaped_name = tornado.escape.xhtml_escape(name)
+        context = {"name": escaped_name}
+        self.render("public/index.html", **context)
 
 application = tornado.web.Application([
     (r"/", MainHandler),


### PR DESCRIPTION
## This solution refers to which of the apps?

[A3] # - sstype

## What did you do to mitigate the vulnerability?

I refactored get method in MainHandler, first got name parameter forcing value escape, after i used 'render' method for pass variables with context format to template and in template i used jinja sintax to render values of the context

Images are not necessary but are greatly appreciated! 📸

## Did you test your changes? What commands did you run?

I used parameters describe in read me, passing values with query params and trying execute commands
