### PR TITLE
fix: Broken image links after Commit 9659261 (#588)

### DIFF
--- a/docs/README_Template.md
+++ b/docs/README_Template.md
@@ -5,7 +5,7 @@
 
 ( Be sure to add a banner image of your app here! )
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/img1.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/img1.png"/>
 </p>
 
 ( Here's a short description of your app! )
@@ -65,25 +65,25 @@ A nice example of images to have on an attack narrative in the discovery section
 First time acessing the app:
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/img1.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/img1.png"/>
 </p>
 
 Found an interesting page:
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/attack1.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/attack1.png"/>
 </p>
 
 Started the analysis on how the app handles cookies:
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/attack3.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/attack3.png"/>
 </p>
 
 Confirmed the suspicion by having a look at the code!
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/attack4.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/attack4.png"/>
 </p>
 
 Add as many images as you can! A picture is worth more than a thousand words!
@@ -104,13 +104,13 @@ Some good examples of images are as follows:
 Creating a payload:
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/attack7.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/attack7.png"/>
 </p>
 
 Delivering a payload, and results!
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/globocom/secDevLabs/master/owasp-top10-2017-apps/a2/saidajaula-monster/images/attack8.png"/>
+    <img src="../owasp-top10-2021-apps/a7/saidajaula-monster/images/attack8.png"/>
 </p>
 
 ## Secure this app


### PR DESCRIPTION
## This solution refers to which of the apps?

Only link fixes to the Documentation. See issue #588 

## Did you test your changes? What commands did you run?

See [how it looks on the PR](https://github.com/lhardt/secDevLabs/blob/master/docs/README_Template.md) vs. [how it looks right now](https://github.com/globocom/secDevLabs/blob/master/docs/README_Template.md)

Relative paths on READMEs are [supported](https://docs.github.com/articles/relative-links-in-readmes) by GitHub and [adopted by this repo](https://github.com/globocom/secDevLabs/blob/master/docs/api-version-issue.md)